### PR TITLE
fix: resolve issues #13, #14, #15 — indexes, settings pages, auth migration

### DIFF
--- a/actions/bookings.ts
+++ b/actions/bookings.ts
@@ -1,28 +1,271 @@
 'use server'
 
-import { getVerifiedSession } from '@/lib/dal'
-import { auth } from '@/lib/firebase'
-import { httpsCallable, getFunctions, connectFunctionsEmulator } from 'firebase/functions'
+import { FieldValue } from 'firebase-admin/firestore'
+import type { Firestore, Transaction } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
-import type { BookingItem } from '@/types'
+import { adminDb } from '@/lib/firebase-admin'
+import { getVerifiedSession } from '@/lib/dal'
+import type { BookingItem, Subscription } from '@/types'
 
-// ---------------------------------------------------------------------------
-// Firebase Callable Functions helper
-// ---------------------------------------------------------------------------
+// ── Internal Firestore document shapes ──────────────────────────────────────
 
-function getFunctionsInstance() {
-  const functions = getFunctions(auth.app, 'us-central1')
-  if (process.env.NODE_ENV === 'development' && process.env.FUNCTIONS_EMULATOR === 'true') {
-    connectFunctionsEmulator(functions, 'localhost', 5001)
+interface CompanyDocumentInternal {
+  subscription: Subscription
+}
+
+interface EquipmentDocumentInternal {
+  name: string
+  active: boolean
+  trackingType: 'individual' | 'quantity'
+  totalQuantity: number
+  requiresApproval: boolean
+  approverId: string | null
+}
+
+interface BookingDocumentInternal {
+  projectName: string
+  notes: string
+  items: BookingItem[]
+  equipmentIds: string[]
+  startDate: string
+  endDate: string
+  userId: string | null
+  status: string
+  requiresApproval: boolean
+  approverId: string | null
+  approvalStatus: string
+  rejectionReason: string | null
+  cancelledAt: null
+  cancelledBy: null
+}
+
+// ── Conflict detection (inlined from Cloud Functions business logic) ──────────
+// These helpers mirror functions/src/bookings/conflictDetection.ts exactly.
+// They cannot be imported from there because functions/ is a separate package.
+
+interface ConflictDetailInternal {
+  equipmentId: string
+  equipmentName: string
+  reason: 'already_booked' | 'insufficient_quantity'
+  requested?: number
+  available?: number
+  conflictingBookingId?: string
+}
+
+interface ConflictResultInternal {
+  hasConflict: boolean
+  conflicts: ConflictDetailInternal[]
+}
+
+interface StoredBookingForConflict {
+  startDate: string
+  endDate: string
+  status: string
+  approvalStatus: string
+  items: BookingItem[]
+  equipmentIds: string[]
+}
+
+/**
+ * Validate items array. Throws a plain Error on failure.
+ */
+function validateItems(rawItems: unknown): BookingItem[] {
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    throw new Error('items must be a non-empty array.')
   }
-  return functions
+  if (rawItems.length > 50) {
+    throw new Error('items may not exceed 50 entries.')
+  }
+  return rawItems.map((entry: unknown, idx: number) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error(`items[${idx}]: each entry must be an object.`)
+    }
+    const { equipmentId, quantity } = entry as Record<string, unknown>
+    if (typeof equipmentId !== 'string' || equipmentId.trim().length === 0) {
+      throw new Error(`items[${idx}].equipmentId is required.`)
+    }
+    if (typeof quantity !== 'number' || !Number.isInteger(quantity) || quantity < 1) {
+      throw new Error(`items[${idx}].quantity must be a positive integer.`)
+    }
+    return { equipmentId: equipmentId.trim(), quantity }
+  })
 }
 
-interface CallableResult {
-  success: boolean
-  bookingId?: string
-  error?: string
+/**
+ * Validate a YYYY-MM-DD date string. Throws a plain Error on failure.
+ */
+function validateDateString(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${fieldName} must be a date string in YYYY-MM-DD format.`)
+  }
+  return value
 }
+
+/**
+ * Extract a flat array of equipment IDs from an items array.
+ */
+function extractEquipmentIds(items: BookingItem[]): string[] {
+  return items.map((i) => i.equipmentId)
+}
+
+/**
+ * Read-only conflict detection — used by the checkConflict pre-check.
+ * Advisory only; write paths use detectConflictsInTransaction.
+ */
+async function detectConflictsReadOnly(
+  db: Firestore,
+  companyId: string,
+  requestedItems: BookingItem[],
+  startDate: string,
+  endDate: string,
+  excludeBookingId?: string,
+): Promise<ConflictResultInternal> {
+  const conflicts: ConflictDetailInternal[] = []
+  const bookingsRef = db.collection(`companies/${companyId}/bookings`)
+
+  for (const item of requestedItems) {
+    const equipmentSnap = await db
+      .doc(`companies/${companyId}/equipment/${item.equipmentId}`)
+      .get()
+
+    if (!equipmentSnap.exists) {
+      conflicts.push({
+        equipmentId: item.equipmentId,
+        equipmentName: 'Unknown',
+        reason: 'already_booked',
+      })
+      continue
+    }
+
+    const equipment = equipmentSnap.data() as EquipmentDocumentInternal
+
+    // Query: bookings referencing this equipment whose endDate >= our startDate.
+    // booking.startDate <= requestedEndDate is checked in memory.
+    const query = await bookingsRef
+      .where('equipmentIds', 'array-contains', item.equipmentId)
+      .where('endDate', '>=', startDate)
+      .get()
+
+    const overlapping = query.docs.filter((doc) => {
+      if (doc.id === excludeBookingId) return false
+      const data = doc.data() as StoredBookingForConflict
+      if (data.status === 'cancelled') return false
+      if (data.approvalStatus === 'rejected') return false
+      return data.startDate <= endDate
+    })
+
+    if (equipment.trackingType === 'individual') {
+      if (overlapping.length > 0) {
+        conflicts.push({
+          equipmentId: item.equipmentId,
+          equipmentName: equipment.name,
+          reason: 'already_booked',
+          conflictingBookingId: overlapping[0].id,
+        })
+      }
+    } else {
+      let sumBooked = 0
+      for (const doc of overlapping) {
+        const data = doc.data() as StoredBookingForConflict
+        const matchingItem = data.items.find((i) => i.equipmentId === item.equipmentId)
+        if (matchingItem) sumBooked += matchingItem.quantity
+      }
+      const available = equipment.totalQuantity - sumBooked
+      if (item.quantity > available) {
+        conflicts.push({
+          equipmentId: item.equipmentId,
+          equipmentName: equipment.name,
+          reason: 'insufficient_quantity',
+          requested: item.quantity,
+          available: Math.max(0, available),
+          conflictingBookingId: overlapping.length > 0 ? overlapping[0].id : undefined,
+        })
+      }
+    }
+  }
+
+  return { hasConflict: conflicts.length > 0, conflicts }
+}
+
+/**
+ * Conflict detection inside a Firestore transaction — authoritative.
+ * Used by createBooking, updateBooking, approveBooking.
+ */
+async function detectConflictsInTransaction(
+  tx: Transaction,
+  db: Firestore,
+  companyId: string,
+  requestedItems: BookingItem[],
+  startDate: string,
+  endDate: string,
+  excludeBookingId?: string,
+): Promise<ConflictResultInternal> {
+  const conflicts: ConflictDetailInternal[] = []
+  const bookingsRef = db.collection(`companies/${companyId}/bookings`)
+
+  for (const item of requestedItems) {
+    const equipmentRef = db.doc(`companies/${companyId}/equipment/${item.equipmentId}`)
+    const equipmentSnap = await tx.get(equipmentRef)
+
+    if (!equipmentSnap.exists) {
+      conflicts.push({
+        equipmentId: item.equipmentId,
+        equipmentName: 'Unknown',
+        reason: 'already_booked',
+      })
+      continue
+    }
+
+    const equipment = equipmentSnap.data() as EquipmentDocumentInternal
+
+    const query = bookingsRef
+      .where('equipmentIds', 'array-contains', item.equipmentId)
+      .where('endDate', '>=', startDate)
+
+    const querySnap = await tx.get(query)
+
+    const overlapping = querySnap.docs.filter((doc) => {
+      if (doc.id === excludeBookingId) return false
+      const data = doc.data() as StoredBookingForConflict
+      if (data.status === 'cancelled') return false
+      if (data.approvalStatus === 'rejected') return false
+      return data.startDate <= endDate
+    })
+
+    if (equipment.trackingType === 'individual') {
+      if (overlapping.length > 0) {
+        conflicts.push({
+          equipmentId: item.equipmentId,
+          equipmentName: equipment.name,
+          reason: 'already_booked',
+          conflictingBookingId: overlapping[0].id,
+        })
+      }
+    } else {
+      let sumBooked = 0
+      for (const doc of overlapping) {
+        const data = doc.data() as StoredBookingForConflict
+        const matchingItem = data.items.find((i) => i.equipmentId === item.equipmentId)
+        if (matchingItem) sumBooked += matchingItem.quantity
+      }
+      const available = equipment.totalQuantity - sumBooked
+      if (item.quantity > available) {
+        conflicts.push({
+          equipmentId: item.equipmentId,
+          equipmentName: equipment.name,
+          reason: 'insufficient_quantity',
+          requested: item.quantity,
+          available: Math.max(0, available),
+          conflictingBookingId: overlapping.length > 0 ? overlapping[0].id : undefined,
+        })
+      }
+    }
+  }
+
+  return { hasConflict: conflicts.length > 0, conflicts }
+}
+
+// ── Public types re-exported for UI consumers ──────────────────────────────
 
 export interface ConflictItem {
   equipmentId: string
@@ -36,9 +279,7 @@ export interface ConflictResult {
   conflicts: ConflictItem[]
 }
 
-// ---------------------------------------------------------------------------
-// createBooking
-// ---------------------------------------------------------------------------
+// ── createBooking ────────────────────────────────────────────────────────────
 
 export async function createBooking(
   formData: FormData,
@@ -46,72 +287,157 @@ export async function createBooking(
   const session = await getVerifiedSession()
   if (session.role === 'viewer') return { error: 'Unauthorized' }
 
+  const companyId = session.activeCompanyId
+
+  // ── Input validation ───────────────────────────────────────────────────────
   const projectName = (formData.get('projectName') as string | null)?.trim() ?? ''
   if (!projectName) return { error: 'Project name is required' }
   if (projectName.length > 200) return { error: 'Project name must be 200 characters or fewer' }
 
-  const startDate = (formData.get('startDate') as string | null)?.trim() ?? ''
-  if (!startDate) return { error: 'Start date is required' }
+  const rawStartDate = (formData.get('startDate') as string | null)?.trim() ?? ''
+  const rawEndDate = (formData.get('endDate') as string | null)?.trim() ?? ''
 
-  const endDate = (formData.get('endDate') as string | null)?.trim() ?? ''
-  if (!endDate) return { error: 'End date is required' }
+  let startDate: string
+  let endDate: string
+  try {
+    startDate = validateDateString(rawStartDate, 'startDate')
+    endDate = validateDateString(rawEndDate, 'endDate')
+  } catch (err) {
+    return { error: (err as Error).message }
+  }
 
   if (endDate < startDate) return { error: 'End date must be on or after start date' }
 
-  const notes = (formData.get('notes') as string | null)?.trim() ?? ''
+  const todayStr = new Date().toISOString().slice(0, 10)
+  if (startDate < todayStr) return { error: 'startDate must be today or a future date.' }
+
+  const notes = (formData.get('notes') as string | null) ?? ''
+  if (typeof notes !== 'string') return { error: 'notes must be a string.' }
   if (notes.length > 2000) return { error: 'Notes must be 2000 characters or fewer' }
 
-  // Items are encoded as JSON in a single "items" field.
   const itemsRaw = formData.get('items') as string | null
   let items: BookingItem[] = []
   try {
-    items = itemsRaw ? (JSON.parse(itemsRaw) as BookingItem[]) : []
-  } catch {
-    return { error: 'Invalid equipment selection' }
+    items = itemsRaw ? validateItems(JSON.parse(itemsRaw)) : []
+  } catch (err) {
+    return { error: (err as Error).message ?? 'Invalid equipment selection' }
   }
 
   if (items.length === 0) return { error: 'At least one equipment item is required' }
-  if (items.length > 50) return { error: 'Maximum 50 equipment items per booking' }
+
+  // ── Transaction ────────────────────────────────────────────────────────────
+  let newBookingId: string
 
   try {
-    const functions = getFunctionsInstance()
-    const fn = httpsCallable<
-      {
-        companyId: string
-        projectName: string
-        startDate: string
-        endDate: string
-        notes: string
-        items: BookingItem[]
-      },
-      CallableResult
-    >(functions, 'createBooking')
+    await adminDb.runTransaction(async (tx) => {
+      // 1. Verify subscription.
+      const companyRef = adminDb.doc(`companies/${companyId}`)
+      const companySnap = await tx.get(companyRef)
+      if (!companySnap.exists) {
+        throw new Error('Company not found.')
+      }
+      const company = companySnap.data() as CompanyDocumentInternal
+      const { status: subStatus } = company.subscription
+      if (subStatus !== 'active' && subStatus !== 'trialing') {
+        throw new Error('Subscription is not active. Reactivate your plan to create bookings.')
+      }
 
-    const result = await fn({
-      companyId: session.activeCompanyId,
-      projectName,
-      startDate,
-      endDate,
-      notes,
-      items,
+      // 2. Validate each equipment item; collect requiresApproval / approverId.
+      let requiresApproval = false
+      let approverId: string | null = null
+
+      for (const item of items) {
+        const equipRef = adminDb.doc(`companies/${companyId}/equipment/${item.equipmentId}`)
+        const equipSnap = await tx.get(equipRef)
+
+        if (!equipSnap.exists) {
+          throw new Error(`Equipment ${item.equipmentId} not found.`)
+        }
+
+        const equipment = equipSnap.data() as EquipmentDocumentInternal
+
+        if (!equipment.active) {
+          throw new Error(`Equipment "${equipment.name}" is not available (deactivated).`)
+        }
+
+        if (equipment.trackingType === 'individual' && item.quantity !== 1) {
+          throw new Error(
+            `Equipment "${equipment.name}" is individually tracked; quantity must be 1.`,
+          )
+        }
+
+        if (
+          equipment.trackingType === 'quantity' &&
+          item.quantity > equipment.totalQuantity
+        ) {
+          throw new Error(
+            `Requested quantity (${item.quantity}) exceeds total stock (${equipment.totalQuantity}) for "${equipment.name}".`,
+          )
+        }
+
+        if (equipment.requiresApproval) {
+          requiresApproval = true
+          if (approverId === null && equipment.approverId) {
+            approverId = equipment.approverId
+          }
+        }
+      }
+
+      // 3. Conflict detection inside the transaction (prevents TOCTOU races).
+      const conflictResult = await detectConflictsInTransaction(
+        tx,
+        adminDb,
+        companyId,
+        items,
+        startDate,
+        endDate,
+      )
+
+      if (conflictResult.hasConflict) {
+        const names = conflictResult.conflicts.map((c) => c.equipmentName).join(', ')
+        throw new Error(`Booking conflict detected for: ${names}.`)
+      }
+
+      // 4. Write the booking document.
+      const bookingsRef = adminDb.collection(`companies/${companyId}/bookings`)
+      const newRef = bookingsRef.doc()
+      newBookingId = newRef.id
+
+      const bookingStatus = requiresApproval ? 'pending' : 'confirmed'
+      const approvalStatus = requiresApproval ? 'pending' : 'none'
+      const equipmentIds = extractEquipmentIds(items)
+
+      tx.set(newRef, {
+        projectName,
+        notes,
+        items,
+        equipmentIds,
+        startDate,
+        endDate,
+        userId: session.uid,
+        userName: null,
+        status: bookingStatus,
+        requiresApproval,
+        approverId,
+        approvalStatus,
+        rejectionReason: null,
+        cancelledAt: null,
+        cancelledBy: null,
+        createdAt: FieldValue.serverTimestamp(),
+        updatedAt: null,
+      })
     })
 
-    if (!result.data.success || !result.data.bookingId) {
-      return { error: result.data.error ?? 'Failed to create booking' }
-    }
-
     revalidatePath('/bookings')
-    return { bookingId: result.data.bookingId }
+    return { bookingId: newBookingId! }
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/bookings] createBooking failed', { code })
-    return { error: 'Failed to create booking' }
+    const message = err instanceof Error ? err.message : 'Failed to create booking'
+    console.error('[actions/bookings] createBooking failed', { message })
+    return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// updateBooking
-// ---------------------------------------------------------------------------
+// ── updateBooking ────────────────────────────────────────────────────────────
 
 export async function updateBooking(
   bookingId: string,
@@ -120,104 +446,257 @@ export async function updateBooking(
   const session = await getVerifiedSession()
   if (session.role === 'viewer') return { error: 'Unauthorized' }
 
-  const payload: Record<string, unknown> = {
-    companyId: session.activeCompanyId,
-    bookingId,
+  const companyId = session.activeCompanyId
+
+  if (!bookingId?.trim()) return { error: 'bookingId is required' }
+
+  // ── Optional field validation ──────────────────────────────────────────────
+  const rawProjectName = formData.get('projectName') as string | null
+  let projectName: string | undefined
+  if (rawProjectName !== null) {
+    const trimmed = rawProjectName.trim()
+    if (trimmed.length === 0) return { error: 'Project name is required' }
+    if (trimmed.length > 200) return { error: 'Project name must be 200 characters or fewer' }
+    projectName = trimmed
   }
 
-  const projectName = (formData.get('projectName') as string | null)?.trim()
-  if (projectName !== null && projectName !== undefined) {
-    if (projectName.length === 0) return { error: 'Project name is required' }
-    if (projectName.length > 200) return { error: 'Project name must be 200 characters or fewer' }
-    payload.projectName = projectName
+  const rawStartDate = formData.get('startDate') as string | null
+  let startDate: string | undefined
+  if (rawStartDate !== null && rawStartDate.trim() !== '') {
+    try {
+      startDate = validateDateString(rawStartDate.trim(), 'startDate')
+    } catch (err) {
+      return { error: (err as Error).message }
+    }
   }
 
-  const startDate = (formData.get('startDate') as string | null)?.trim()
-  if (startDate) payload.startDate = startDate
-
-  const endDate = (formData.get('endDate') as string | null)?.trim()
-  if (endDate) payload.endDate = endDate
-
-  if (startDate && endDate && endDate < startDate) {
-    return { error: 'End date must be on or after start date' }
+  const rawEndDate = formData.get('endDate') as string | null
+  let endDate: string | undefined
+  if (rawEndDate !== null && rawEndDate.trim() !== '') {
+    try {
+      endDate = validateDateString(rawEndDate.trim(), 'endDate')
+    } catch (err) {
+      return { error: (err as Error).message }
+    }
   }
 
-  const notes = (formData.get('notes') as string | null)?.trim()
-  if (notes !== null && notes !== undefined) {
-    if (notes.length > 2000) return { error: 'Notes must be 2000 characters or fewer' }
-    payload.notes = notes
+  const rawNotes = formData.get('notes') as string | null
+  let notes: string | undefined
+  if (rawNotes !== null) {
+    if (typeof rawNotes !== 'string') return { error: 'notes must be a string.' }
+    if (rawNotes.length > 2000) return { error: 'Notes must be 2000 characters or fewer' }
+    notes = rawNotes
   }
 
   const itemsRaw = formData.get('items') as string | null
+  let items: BookingItem[] | undefined
   if (itemsRaw) {
     try {
-      const items = JSON.parse(itemsRaw) as BookingItem[]
-      if (items.length === 0) return { error: 'At least one equipment item is required' }
-      if (items.length > 50) return { error: 'Maximum 50 equipment items per booking' }
-      payload.items = items
-    } catch {
-      return { error: 'Invalid equipment selection' }
+      items = validateItems(JSON.parse(itemsRaw))
+    } catch (err) {
+      return { error: (err as Error).message ?? 'Invalid equipment selection' }
     }
+    if (items.length === 0) return { error: 'At least one equipment item is required' }
   }
 
-  try {
-    const functions = getFunctionsInstance()
-    const fn = httpsCallable<Record<string, unknown>, CallableResult>(functions, 'updateBooking')
-    const result = await fn(payload)
+  const uid = session.uid
+  const isAdmin = session.role === 'admin'
 
-    if (!result.data.success) {
-      return { error: result.data.error ?? 'Failed to update booking' }
-    }
+  try {
+    await adminDb.runTransaction(async (tx) => {
+      const bookingRef = adminDb.doc(`companies/${companyId}/bookings/${bookingId}`)
+      const bookingSnap = await tx.get(bookingRef)
+
+      if (!bookingSnap.exists) {
+        throw new Error('Booking not found.')
+      }
+
+      const booking = bookingSnap.data() as BookingDocumentInternal
+
+      // ── Ownership / role check ─────────────────────────────────────────────
+      if (!isAdmin && booking.userId !== uid) {
+        throw new Error('You can only edit your own bookings.')
+      }
+
+      // ── Status check ──────────────────────────────────────────────────────
+      if (booking.status !== 'pending' && booking.status !== 'confirmed') {
+        throw new Error(`Cannot edit a booking with status '${booking.status}'.`)
+      }
+
+      const effectiveItems = items ?? booking.items
+      const effectiveStartDate = startDate ?? booking.startDate
+      const effectiveEndDate = endDate ?? booking.endDate
+
+      if (effectiveEndDate < effectiveStartDate) {
+        throw new Error('endDate must be on or after startDate.')
+      }
+
+      // ── Re-validate equipment if items changed ─────────────────────────────
+      let requiresApproval = booking.requiresApproval
+      let approverId = booking.approverId
+
+      if (items !== undefined) {
+        requiresApproval = false
+        approverId = null
+
+        for (const item of items) {
+          const equipRef = adminDb.doc(`companies/${companyId}/equipment/${item.equipmentId}`)
+          const equipSnap = await tx.get(equipRef)
+
+          if (!equipSnap.exists) {
+            throw new Error(`Equipment ${item.equipmentId} not found.`)
+          }
+
+          const equipment = equipSnap.data() as EquipmentDocumentInternal
+
+          if (!equipment.active) {
+            throw new Error(`Equipment "${equipment.name}" is not available (deactivated).`)
+          }
+
+          if (equipment.trackingType === 'individual' && item.quantity !== 1) {
+            throw new Error(
+              `Equipment "${equipment.name}" is individually tracked; quantity must be 1.`,
+            )
+          }
+
+          if (
+            equipment.trackingType === 'quantity' &&
+            item.quantity > equipment.totalQuantity
+          ) {
+            throw new Error(
+              `Requested quantity (${item.quantity}) exceeds total stock (${equipment.totalQuantity}) for "${equipment.name}".`,
+            )
+          }
+
+          if (equipment.requiresApproval) {
+            requiresApproval = true
+            if (approverId === null && equipment.approverId) {
+              approverId = equipment.approverId
+            }
+          }
+        }
+      }
+
+      // ── Conflict detection if dates or items changed ───────────────────────
+      const datesChanged = startDate !== undefined || endDate !== undefined
+      const itemsChanged = items !== undefined
+
+      if (datesChanged || itemsChanged) {
+        const conflictResult = await detectConflictsInTransaction(
+          tx,
+          adminDb,
+          companyId,
+          effectiveItems,
+          effectiveStartDate,
+          effectiveEndDate,
+          bookingId,
+        )
+
+        if (conflictResult.hasConflict) {
+          const names = conflictResult.conflicts.map((c) => c.equipmentName).join(', ')
+          throw new Error(`Booking conflict detected for: ${names}.`)
+        }
+      }
+
+      // ── Build update payload ───────────────────────────────────────────────
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const updateData: Record<string, any> = {
+        updatedAt: FieldValue.serverTimestamp(),
+      }
+
+      if (projectName !== undefined) updateData.projectName = projectName
+      if (notes !== undefined) updateData.notes = notes
+      if (startDate !== undefined) updateData.startDate = startDate
+      if (endDate !== undefined) updateData.endDate = endDate
+      if (items !== undefined) {
+        updateData.items = items
+        updateData.equipmentIds = extractEquipmentIds(items)
+        updateData.requiresApproval = requiresApproval
+        updateData.approverId = approverId
+      }
+
+      if (datesChanged || itemsChanged) {
+        if (requiresApproval) {
+          updateData.status = 'pending'
+          updateData.approvalStatus = 'pending'
+          updateData.rejectionReason = null
+        } else {
+          updateData.status = 'confirmed'
+          updateData.approvalStatus = 'none'
+          updateData.rejectionReason = null
+        }
+      }
+
+      tx.update(bookingRef, updateData)
+    })
 
     revalidatePath('/bookings')
     revalidatePath(`/bookings/${bookingId}`)
     return {}
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/bookings] updateBooking failed', { code })
-    return { error: 'Failed to update booking' }
+    const message = err instanceof Error ? err.message : 'Failed to update booking'
+    console.error('[actions/bookings] updateBooking failed', { message })
+    return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// cancelBooking
-// ---------------------------------------------------------------------------
+// ── cancelBooking ────────────────────────────────────────────────────────────
 
-export async function cancelBooking(
-  bookingId: string,
-): Promise<{ error?: string }> {
+export async function cancelBooking(bookingId: string): Promise<{ error?: string }> {
   const session = await getVerifiedSession()
   if (session.role === 'viewer') return { error: 'Unauthorized' }
 
+  const companyId = session.activeCompanyId
+
+  if (!bookingId?.trim()) return { error: 'bookingId is required' }
+
+  const uid = session.uid
+  const isAdmin = session.role === 'admin'
+
   try {
-    const functions = getFunctionsInstance()
-    const fn = httpsCallable<
-      { companyId: string; bookingId: string },
-      CallableResult
-    >(functions, 'cancelBooking')
+    await adminDb.runTransaction(async (tx) => {
+      const bookingRef = adminDb.doc(`companies/${companyId}/bookings/${bookingId}`)
+      const bookingSnap = await tx.get(bookingRef)
 
-    const result = await fn({
-      companyId: session.activeCompanyId,
-      bookingId,
+      if (!bookingSnap.exists) {
+        throw new Error('Booking not found.')
+      }
+
+      const booking = bookingSnap.data() as BookingDocumentInternal
+
+      if (!isAdmin && booking.userId !== uid) {
+        throw new Error('You can only cancel your own bookings.')
+      }
+
+      if (booking.status === 'cancelled') {
+        throw new Error('Booking is already cancelled.')
+      }
+      if (booking.status === 'returned') {
+        throw new Error('Cannot cancel a returned booking.')
+      }
+      if (booking.status === 'checked_out') {
+        throw new Error('Cannot cancel a checked-out booking. Return the equipment first.')
+      }
+
+      tx.update(bookingRef, {
+        status: 'cancelled',
+        cancelledAt: FieldValue.serverTimestamp(),
+        cancelledBy: uid,
+        updatedAt: FieldValue.serverTimestamp(),
+      })
     })
-
-    if (!result.data.success) {
-      return { error: result.data.error ?? 'Failed to cancel booking' }
-    }
 
     revalidatePath('/bookings')
     revalidatePath(`/bookings/${bookingId}`)
     return {}
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/bookings] cancelBooking failed', { code })
-    return { error: 'Failed to cancel booking' }
+    const message = err instanceof Error ? err.message : 'Failed to cancel booking'
+    console.error('[actions/bookings] cancelBooking failed', { message })
+    return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// approveBooking (wraps both approveBooking and rejectBooking Cloud Functions)
-// ---------------------------------------------------------------------------
+// ── approveBooking (wraps both approve and reject) ───────────────────────────
 
 export async function approveBooking(
   bookingId: string,
@@ -227,53 +706,94 @@ export async function approveBooking(
   const session = await getVerifiedSession()
   if (session.role === 'viewer') return { error: 'Unauthorized' }
 
+  const companyId = session.activeCompanyId
+
+  if (!bookingId?.trim()) return { error: 'bookingId is required' }
+
+  // Optional reason validation (reject path only).
+  let validatedReason: string | null = null
+  if (!approved && rejectionReason !== undefined && rejectionReason !== null) {
+    if (typeof rejectionReason !== 'string') return { error: 'reason must be a string.' }
+    if (rejectionReason.length > 500) return { error: 'reason must be 500 characters or fewer.' }
+    validatedReason = rejectionReason.trim() || null
+  }
+
+  const uid = session.uid
+  const isAdmin = session.role === 'admin'
+
   try {
-    const functions = getFunctionsInstance()
+    await adminDb.runTransaction(async (tx) => {
+      const bookingRef = adminDb.doc(`companies/${companyId}/bookings/${bookingId}`)
+      const bookingSnap = await tx.get(bookingRef)
 
-    if (approved) {
-      const fn = httpsCallable<
-        { companyId: string; bookingId: string },
-        CallableResult
-      >(functions, 'approveBooking')
-
-      const result = await fn({
-        companyId: session.activeCompanyId,
-        bookingId,
-      })
-
-      if (!result.data.success) {
-        return { error: result.data.error ?? 'Failed to approve booking' }
+      if (!bookingSnap.exists) {
+        throw new Error('Booking not found.')
       }
-    } else {
-      const fn = httpsCallable<
-        { companyId: string; bookingId: string; reason?: string },
-        CallableResult
-      >(functions, 'rejectBooking')
 
-      const result = await fn({
-        companyId: session.activeCompanyId,
-        bookingId,
-        reason: rejectionReason,
-      })
+      const booking = bookingSnap.data() as BookingDocumentInternal
 
-      if (!result.data.success) {
-        return { error: result.data.error ?? 'Failed to reject booking' }
+      // ── State check ──────────────────────────────────────────────────────
+      if (booking.status !== 'pending' || booking.approvalStatus !== 'pending') {
+        throw new Error('Booking is not awaiting approval.')
       }
-    }
+
+      // ── Approver check ────────────────────────────────────────────────────
+      const isDesignatedApprover = booking.approverId !== null && booking.approverId === uid
+
+      if (!isAdmin && !isDesignatedApprover) {
+        throw new Error(
+          approved
+            ? 'Only the designated approver or an admin can approve this booking.'
+            : 'Only the designated approver or an admin can reject this booking.',
+        )
+      }
+
+      if (approved) {
+        // Re-run conflict detection before confirming — availability may have
+        // changed since the booking was originally created.
+        const conflictResult = await detectConflictsInTransaction(
+          tx,
+          adminDb,
+          companyId,
+          booking.items,
+          booking.startDate,
+          booking.endDate,
+          bookingId,
+        )
+
+        if (conflictResult.hasConflict) {
+          const names = conflictResult.conflicts.map((c) => c.equipmentName).join(', ')
+          throw new Error(
+            `Cannot approve: conflict detected for ${names}. Resolve conflicts before approving.`,
+          )
+        }
+
+        tx.update(bookingRef, {
+          status: 'confirmed',
+          approvalStatus: 'approved',
+          updatedAt: FieldValue.serverTimestamp(),
+        })
+      } else {
+        // status stays 'pending'; only approvalStatus changes.
+        tx.update(bookingRef, {
+          approvalStatus: 'rejected',
+          rejectionReason: validatedReason,
+          updatedAt: FieldValue.serverTimestamp(),
+        })
+      }
+    })
 
     revalidatePath('/bookings')
     revalidatePath(`/bookings/${bookingId}`)
     return {}
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/bookings] approveBooking failed', { code })
-    return { error: 'Failed to update approval' }
+    const message = err instanceof Error ? err.message : 'Failed to update approval'
+    console.error('[actions/bookings] approveBooking failed', { message })
+    return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// checkConflict (read-only pre-check — not authoritative, Cloud Function is)
-// ---------------------------------------------------------------------------
+// ── checkConflict (read-only pre-check) ─────────────────────────────────────
 
 export async function checkConflict(
   companyId: string,
@@ -284,36 +804,52 @@ export async function checkConflict(
 ): Promise<ConflictResult> {
   const session = await getVerifiedSession()
 
-  // Security: ignore caller-supplied companyId if it doesn't match the session.
+  // Ignore caller-supplied companyId if it doesn't match the session.
   if (companyId !== session.activeCompanyId) {
     return { hasConflict: false, conflicts: [] }
   }
 
+  let validatedItems: BookingItem[]
+  let validatedStart: string
+  let validatedEnd: string
+
   try {
-    const functions = getFunctionsInstance()
-    const fn = httpsCallable<
-      {
-        companyId: string
-        startDate: string
-        endDate: string
-        items: BookingItem[]
-        excludeBookingId?: string
-      },
-      ConflictResult
-    >(functions, 'checkBookingConflict')
+    validatedItems = validateItems(items)
+    validatedStart = validateDateString(startDate, 'startDate')
+    validatedEnd = validateDateString(endDate, 'endDate')
+  } catch {
+    // Invalid input — return no conflicts; authoritative check runs on submit.
+    return { hasConflict: false, conflicts: [] }
+  }
 
-    const result = await fn({
-      companyId,
-      startDate,
-      endDate,
-      items,
+  if (validatedEnd < validatedStart) {
+    return { hasConflict: false, conflicts: [] }
+  }
+
+  try {
+    const result = await detectConflictsReadOnly(
+      adminDb,
+      session.activeCompanyId,
+      validatedItems,
+      validatedStart,
+      validatedEnd,
       excludeBookingId,
-    })
+    )
 
-    return result.data
+    // Map internal ConflictDetail to the exported ConflictItem shape.
+    return {
+      hasConflict: result.hasConflict,
+      conflicts: result.conflicts.map((c) => ({
+        equipmentId: c.equipmentId,
+        reason: c.reason,
+        requested: c.requested,
+        available: c.available,
+      })),
+    }
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/bookings] checkConflict failed', { code })
+    console.error('[actions/bookings] checkConflict failed', {
+      message: err instanceof Error ? err.message : String(err),
+    })
     // On failure return no conflicts — the authoritative check is on submit.
     return { hasConflict: false, conflicts: [] }
   }

--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -1,46 +1,24 @@
 'use server'
 
-import { getVerifiedSession } from '@/lib/dal'
-import { auth } from '@/lib/firebase'
-import { httpsCallable, getFunctions, connectFunctionsEmulator } from 'firebase/functions'
+import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
+import { adminDb } from '@/lib/firebase-admin'
+import { getVerifiedSession } from '@/lib/dal'
+import type { Subscription } from '@/types'
 
-// ---------------------------------------------------------------------------
-// Firebase Callable Functions helper
-// ---------------------------------------------------------------------------
-// We call Cloud Functions from Server Actions using the client SDK.
-// The functions run server-side (Cloud Functions), so actual business logic
-// and limit enforcement live there — not here.
-// ---------------------------------------------------------------------------
+// ── Internal Firestore document shapes ──────────────────────────────────────
 
-function getFunctionsInstance() {
-  const functions = getFunctions(auth.app, 'us-central1')
-  if (process.env.NODE_ENV === 'development' && process.env.FUNCTIONS_EMULATOR === 'true') {
-    connectFunctionsEmulator(functions, 'localhost', 5001)
-  }
-  return functions
+interface CompanyDocumentInternal {
+  subscription: Subscription
 }
 
-// ---------------------------------------------------------------------------
-// createEquipment
-// ---------------------------------------------------------------------------
-
-interface CreateEquipmentPayload {
+interface EquipmentDocumentInternal {
+  trackingType?: string
+  active: boolean
   name: string
-  category: string
-  trackingType: 'individual' | 'quantity'
-  totalQuantity: number
-  serialNumber: string | null
-  status: string
-  requiresApproval: boolean
-  approverId: string | null
 }
 
-interface CallableFunctionResult {
-  success: boolean
-  data?: { id: string }
-  error?: string
-}
+// ── createEquipment ──────────────────────────────────────────────────────────
 
 export async function createEquipment(
   formData: FormData,
@@ -48,73 +26,125 @@ export async function createEquipment(
   const session = await getVerifiedSession()
   if (session.role !== 'admin') return { error: 'Unauthorized' }
 
+  const companyId = session.activeCompanyId
+
+  // ── Input validation ───────────────────────────────────────────────────────
   const name = (formData.get('name') as string | null)?.trim() ?? ''
   if (!name) return { error: 'Name is required' }
   if (name.length > 100) return { error: 'Name must be 100 characters or fewer' }
 
   const category = (formData.get('category') as string | null)?.trim() ?? ''
-  const trackingType = (formData.get('trackingType') as string | null) === 'quantity' ? 'quantity' : 'individual'
-  const totalQuantity = trackingType === 'quantity'
-    ? parseInt(formData.get('totalQuantity') as string ?? '1', 10) || 1
-    : 1
-  const serialNumberRaw = formData.get('serialNumber') as string | null
-  const serialNumber = trackingType === 'individual' ? (serialNumberRaw?.trim() || null) : null
-  const status = (formData.get('status') as string | null) ?? 'available'
-  const requiresApproval = formData.get('requiresApproval') === 'true'
-  const approverIdRaw = formData.get('approverId') as string | null
-  const approverId = approverIdRaw?.trim() || null
+  if (!category) return { error: 'Category is required' }
 
-  const payload: CreateEquipmentPayload = {
-    name,
-    category,
-    trackingType,
-    totalQuantity,
-    serialNumber,
-    status,
-    requiresApproval,
-    approverId,
+  const VALID_STATUSES = ['available', 'checked_out', 'needs_repair'] as const
+  type EquipmentStatus = (typeof VALID_STATUSES)[number]
+
+  const rawStatus = formData.get('status') as string | null
+  let status: EquipmentStatus = 'available'
+  if (rawStatus !== null && rawStatus !== undefined) {
+    if (!VALID_STATUSES.includes(rawStatus as EquipmentStatus)) {
+      return { error: `status must be one of: ${VALID_STATUSES.join(', ')}` }
+    }
+    status = rawStatus as EquipmentStatus
   }
 
-  try {
-    const functions = getFunctionsInstance()
-    const addEquipment = httpsCallable<
-      { companyId: string } & CreateEquipmentPayload,
-      CallableFunctionResult
-    >(functions, 'addEquipment')
+  const trackingType =
+    (formData.get('trackingType') as string | null) === 'quantity' ? 'quantity' : 'individual'
 
-    const result = await addEquipment({ companyId: session.activeCompanyId, ...payload })
-
-    if (!result.data.success || !result.data.data?.id) {
-      return { error: result.data.error ?? 'Failed to create equipment' }
+  let totalQuantity = 1
+  if (trackingType === 'quantity') {
+    const raw = parseInt(formData.get('totalQuantity') as string ?? '0', 10)
+    if (!Number.isInteger(raw) || raw < 1) {
+      return { error: 'totalQuantity must be a positive integer for quantity items' }
     }
+    totalQuantity = raw
+  }
+
+  const serialNumberRaw = formData.get('serialNumber') as string | null
+  if (trackingType === 'quantity' && serialNumberRaw !== null && serialNumberRaw !== '') {
+    return { error: 'serialNumber is not allowed for quantity-tracked items' }
+  }
+  const serialNumber: string | null =
+    trackingType === 'individual' ? (serialNumberRaw?.trim() || null) : null
+
+  const requiresApproval = formData.get('requiresApproval') === 'true'
+  const approverIdRaw = formData.get('approverId') as string | null
+  const approverId: string | null = approverIdRaw?.trim() || null
+
+  // ── Transaction: check plan limit + write atomically ──────────────────────
+  let newEquipmentId: string
+
+  try {
+    await adminDb.runTransaction(async (tx) => {
+      const companyRef = adminDb.doc(`companies/${companyId}`)
+      const companySnap = await tx.get(companyRef)
+
+      if (!companySnap.exists) {
+        throw Object.assign(new Error('Company not found.'), { code: 'not-found' })
+      }
+
+      const company = companySnap.data() as CompanyDocumentInternal
+      const { subscription } = company
+
+      if (subscription.status !== 'trialing' && subscription.status !== 'active') {
+        throw Object.assign(
+          new Error('Subscription is not active. Reactivate your plan to add equipment.'),
+          { code: 'failed-precondition' },
+        )
+      }
+
+      // Count active equipment. Aggregation queries cannot run inside
+      // runTransaction, so we query outside and accept the negligible TOCTOU
+      // window — this is a soft cap, not a security boundary.
+      const countSnap = await adminDb
+        .collection(`companies/${companyId}/equipment`)
+        .where('active', '==', true)
+        .count()
+        .get()
+      const currentCount = countSnap.data().count
+
+      const limit = subscription.limits.equipment
+      const plan = subscription.plan
+
+      if (currentCount >= limit) {
+        throw Object.assign(
+          new Error(
+            `Equipment limit reached. Your ${plan} plan allows ${limit} items. Upgrade to add more.`,
+          ),
+          { code: 'resource-exhausted' },
+        )
+      }
+
+      const newRef = adminDb.collection(`companies/${companyId}/equipment`).doc()
+      newEquipmentId = newRef.id
+
+      tx.set(newRef, {
+        name,
+        category,
+        trackingType,
+        totalQuantity,
+        serialNumber,
+        status,
+        active: true,
+        requiresApproval,
+        approverId,
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: session.uid,
+      })
+    })
 
     revalidatePath('/equipment')
     revalidatePath('/settings/equipment')
 
-    return { id: result.data.data.id }
+    return { id: newEquipmentId! }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to create equipment'
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/equipment] createEquipment failed', { code })
+    console.error('[actions/equipment] createEquipment failed', { message })
     return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// updateEquipment
-// ---------------------------------------------------------------------------
-
-interface UpdateEquipmentPayload {
-  name?: string
-  category?: string
-  // trackingType intentionally omitted — immutable after creation
-  totalQuantity?: number
-  serialNumber?: string | null
-  status?: string
-  requiresApproval?: boolean
-  approverId?: string | null
-  // active intentionally omitted — deactivation routes through deactivateEquipment only
-}
+// ── updateEquipment ──────────────────────────────────────────────────────────
 
 export async function updateEquipment(
   equipmentId: string,
@@ -123,59 +153,101 @@ export async function updateEquipment(
   const session = await getVerifiedSession()
   if (session.role !== 'admin') return { error: 'Unauthorized' }
 
-  const name = (formData.get('name') as string | null)?.trim()
-  if (name !== undefined && name !== null && name.length > 100) {
-    return { error: 'Name must be 100 characters or fewer' }
-  }
-  if (name !== undefined && name !== null && name.length === 0) {
-    return { error: 'Name cannot be empty' }
-  }
+  const companyId = session.activeCompanyId
 
-  const payload: UpdateEquipmentPayload = {}
-  if (name) payload.name = name
+  if (!equipmentId?.trim()) return { error: 'equipmentId is required' }
 
-  const category = (formData.get('category') as string | null)?.trim()
-  if (category) payload.category = category
-
-  const totalQuantityRaw = formData.get('totalQuantity')
-  if (totalQuantityRaw !== null) {
-    payload.totalQuantity = parseInt(totalQuantityRaw as string, 10) || 1
+  // trackingType is immutable — reject any attempt to change it.
+  if (formData.get('trackingType') !== null) {
+    return {
+      error: 'trackingType cannot be changed after creation. Deactivate this item and create a new one.',
+    }
   }
 
-  const serialNumberRaw = formData.get('serialNumber')
-  if (serialNumberRaw !== null) {
-    payload.serialNumber = (serialNumberRaw as string).trim() || null
+  // ── Fetch existing document ────────────────────────────────────────────────
+  const equipmentRef = adminDb.doc(`companies/${companyId}/equipment/${equipmentId}`)
+  const equipmentSnap = await equipmentRef.get()
+
+  if (!equipmentSnap.exists) {
+    return { error: 'Equipment not found.' }
   }
 
-  const status = formData.get('status') as string | null
-  if (status) payload.status = status
+  const existingData = equipmentSnap.data() as EquipmentDocumentInternal
 
-  const requiresApprovalRaw = formData.get('requiresApproval')
-  if (requiresApprovalRaw !== null) {
-    payload.requiresApproval = requiresApprovalRaw === 'true'
+  // ── Build partial update payload ───────────────────────────────────────────
+  const VALID_STATUSES = ['available', 'checked_out', 'needs_repair'] as const
+  type EquipmentStatus = (typeof VALID_STATUSES)[number]
+
+  const updates: Record<string, unknown> = {
+    updatedAt: FieldValue.serverTimestamp(),
   }
 
-  const approverIdRaw = formData.get('approverId') as string | null
-  if (approverIdRaw !== null) {
-    payload.approverId = approverIdRaw.trim() || null
+  const rawName = formData.get('name') as string | null
+  if (rawName !== null) {
+    const name = rawName.trim()
+    if (name.length === 0) return { error: 'name must be a non-empty string.' }
+    if (name.length > 100) return { error: 'name must be 100 characters or fewer.' }
+    updates['name'] = name
+  }
+
+  const rawCategory = formData.get('category') as string | null
+  if (rawCategory !== null) {
+    const category = rawCategory.trim()
+    if (category.length === 0) return { error: 'category must be a non-empty string.' }
+    updates['category'] = category
+  }
+
+  const rawStatus = formData.get('status') as string | null
+  if (rawStatus !== null) {
+    if (!VALID_STATUSES.includes(rawStatus as EquipmentStatus)) {
+      return { error: `status must be one of: ${VALID_STATUSES.join(', ')}.` }
+    }
+    updates['status'] = rawStatus as EquipmentStatus
+  }
+
+  const rawRequiresApproval = formData.get('requiresApproval')
+  if (rawRequiresApproval !== null) {
+    updates['requiresApproval'] = rawRequiresApproval === 'true'
+  }
+
+  const rawApproverId = formData.get('approverId') as string | null
+  if (rawApproverId !== null) {
+    updates['approverId'] = rawApproverId.trim() || null
+  }
+
+  const rawTotalQuantity = formData.get('totalQuantity')
+  if (rawTotalQuantity !== null) {
+    if (
+      existingData.trackingType !== undefined &&
+      existingData.trackingType !== 'quantity'
+    ) {
+      return { error: 'totalQuantity can only be updated on quantity-tracked items.' }
+    }
+    if (existingData.trackingType !== undefined) {
+      const qty = parseInt(rawTotalQuantity as string, 10)
+      if (!Number.isInteger(qty) || qty < 1) {
+        return { error: 'totalQuantity must be a positive integer.' }
+      }
+      updates['totalQuantity'] = qty
+    }
+  }
+
+  const rawSerialNumber = formData.get('serialNumber')
+  if (rawSerialNumber !== null) {
+    if (
+      existingData.trackingType !== undefined &&
+      existingData.trackingType !== 'individual'
+    ) {
+      return { error: 'serialNumber is not allowed on quantity-tracked items.' }
+    }
+    if (existingData.trackingType !== undefined) {
+      updates['serialNumber'] =
+        rawSerialNumber ? (rawSerialNumber as string).trim() || null : null
+    }
   }
 
   try {
-    const functions = getFunctionsInstance()
-    const updateEquipmentFn = httpsCallable<
-      { companyId: string; equipmentId: string } & UpdateEquipmentPayload,
-      CallableFunctionResult
-    >(functions, 'updateEquipment')
-
-    const result = await updateEquipmentFn({
-      companyId: session.activeCompanyId,
-      equipmentId,
-      ...payload,
-    })
-
-    if (!result.data.success) {
-      return { error: result.data.error ?? 'Failed to update equipment' }
-    }
+    await equipmentRef.update(updates)
 
     revalidatePath('/equipment')
     revalidatePath('/settings/equipment')
@@ -183,44 +255,72 @@ export async function updateEquipment(
     return {}
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to update equipment'
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/equipment] updateEquipment failed', { code })
+    console.error('[actions/equipment] updateEquipment failed', { message })
     return { error: message }
   }
 }
 
-// ---------------------------------------------------------------------------
-// deactivateEquipment  (soft delete — sets active: false)
-// ---------------------------------------------------------------------------
+// ── deactivateEquipment ──────────────────────────────────────────────────────
 
-export async function deactivateEquipment(equipmentId: string): Promise<{ error?: string }> {
+export async function deactivateEquipment(
+  equipmentId: string,
+  force = false,
+): Promise<
+  | { success: true }
+  | { requiresForce: true; affectedBookingCount: number }
+  | { error: string }
+> {
   const session = await getVerifiedSession()
   if (session.role !== 'admin') return { error: 'Unauthorized' }
 
-  try {
-    const functions = getFunctionsInstance()
-    const deactivateEquipmentFn = httpsCallable<
-      { companyId: string; equipmentId: string },
-      CallableFunctionResult
-    >(functions, 'deactivateEquipment')
+  const companyId = session.activeCompanyId
 
-    const result = await deactivateEquipmentFn({
-      companyId: session.activeCompanyId,
-      equipmentId,
-    })
+  if (!equipmentId?.trim()) return { error: 'equipmentId is required' }
 
-    if (!result.data.success) {
-      return { error: result.data.error ?? 'Failed to deactivate equipment' }
+  const equipmentRef = adminDb.doc(`companies/${companyId}/equipment/${equipmentId}`)
+  const equipmentSnap = await equipmentRef.get()
+
+  if (!equipmentSnap.exists) {
+    return { error: 'Equipment not found.' }
+  }
+
+  // ── Active/upcoming booking check ──────────────────────────────────────────
+  // Query by equipmentIds array-contains + endDate range; filter by status in memory.
+  // (Firestore does not support array-contains combined with 'in' in one query.)
+  const ACTIVE_STATUSES = new Set(['pending', 'confirmed', 'checked_out'])
+  const todayStr = new Date().toISOString().slice(0, 10)
+
+  const bookingsSnap = await adminDb
+    .collection(`companies/${companyId}/bookings`)
+    .where('equipmentIds', 'array-contains', equipmentId)
+    .where('endDate', '>=', todayStr)
+    .get()
+
+  const activeBookings = bookingsSnap.docs.filter((doc) => {
+    const data = doc.data()
+    return ACTIVE_STATUSES.has(data.status as string)
+  })
+
+  if (activeBookings.length > 0 && !force) {
+    return {
+      requiresForce: true,
+      affectedBookingCount: activeBookings.length,
     }
+  }
+
+  try {
+    await equipmentRef.update({
+      active: false,
+      deactivatedAt: FieldValue.serverTimestamp(),
+    })
 
     revalidatePath('/equipment')
     revalidatePath('/settings/equipment')
 
-    return {}
+    return { success: true }
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to deactivate equipment'
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/equipment] deactivateEquipment failed', { code })
+    console.error('[actions/equipment] deactivateEquipment failed', { message })
     return { error: message }
   }
 }

--- a/app/(app)/settings/company/page.tsx
+++ b/app/(app)/settings/company/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation'
+import { getVerifiedSession } from '@/lib/dal'
+import { getCompany } from '@/lib/queries/company'
+import CompanySettingsForm from '@/components/settings/CompanySettingsForm'
+
+/**
+ * Settings › Company — Server Component.
+ * Fetches company data server-side and passes it to the client form.
+ */
+export default async function CompanySettingsPage() {
+  const session = await getVerifiedSession()
+  const company = await getCompany(session.activeCompanyId)
+
+  if (!company) {
+    notFound()
+  }
+
+  return <CompanySettingsForm name={company.name} />
+}

--- a/app/(app)/settings/layout.tsx
+++ b/app/(app)/settings/layout.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation'
+import { getVerifiedSession } from '@/lib/dal'
+import SettingsSecondaryNav from '@/components/nav/SettingsSecondaryNav'
+
+/**
+ * Settings layout — Server Component.
+ * Admin-only. Redirects non-admins to /bookings.
+ * Renders the secondary sub-nav (Company | Team | Subscription).
+ */
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const session = await getVerifiedSession()
+
+  if (session.role !== 'admin') {
+    redirect('/bookings')
+  }
+
+  return (
+    <>
+      <SettingsSecondaryNav />
+      {children}
+    </>
+  )
+}

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation'
+
+/**
+ * /settings → redirect to /settings/company (the default tab).
+ */
+export default function SettingsPage() {
+  redirect('/settings/company')
+}

--- a/app/(app)/settings/subscription/page.tsx
+++ b/app/(app)/settings/subscription/page.tsx
@@ -1,0 +1,14 @@
+import { getVerifiedSession } from '@/lib/dal'
+import { getCompany } from '@/lib/queries/company'
+import SubscriptionView from '@/components/settings/SubscriptionView'
+
+/**
+ * Settings › Subscription — Server Component.
+ * Fetches company data server-side and passes subscription to the client view.
+ */
+export default async function SubscriptionSettingsPage() {
+  const session = await getVerifiedSession()
+  const company = await getCompany(session.activeCompanyId)
+
+  return <SubscriptionView subscription={company?.subscription ?? null} />
+}

--- a/app/(app)/settings/team/page.tsx
+++ b/app/(app)/settings/team/page.tsx
@@ -1,0 +1,17 @@
+import { getVerifiedSession } from '@/lib/dal'
+import TeamSettingsView from '@/components/settings/TeamSettingsView'
+
+/**
+ * Settings › Team — Server Component.
+ * Passes companyId and currentUserId from the verified session to the client view.
+ */
+export default async function TeamSettingsPage() {
+  const session = await getVerifiedSession()
+
+  return (
+    <TeamSettingsView
+      companyId={session.activeCompanyId}
+      currentUserId={session.uid}
+    />
+  )
+}

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -44,7 +44,7 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
     setActionError(null)
     const result = await deactivateEquipment(item.id)
     setDeactivatingId(null)
-    if (result.error) {
+    if ('error' in result) {
       setActionError(result.error)
     }
   }

--- a/components/nav/SettingsSecondaryNav.module.css
+++ b/components/nav/SettingsSecondaryNav.module.css
@@ -1,0 +1,24 @@
+.nav {
+  display: flex;
+  align-items: baseline;
+  gap: 32px;
+  padding: 10px var(--booking-pad-h);
+  border-bottom: 1px solid var(--rule);
+}
+
+.item {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mid);
+  transition: color 0.15s ease;
+}
+
+.item:hover {
+  color: var(--white);
+}
+
+.itemActive {
+  color: var(--white);
+}

--- a/components/nav/SettingsSecondaryNav.tsx
+++ b/components/nav/SettingsSecondaryNav.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import styles from './SettingsSecondaryNav.module.css'
+
+interface NavItem {
+  label: string
+  href: string
+}
+
+const ITEMS: NavItem[] = [
+  { label: 'Company',      href: '/settings/company' },
+  { label: 'Team',         href: '/settings/team' },
+  { label: 'Subscription', href: '/settings/subscription' },
+]
+
+/**
+ * Secondary nav for the settings section.
+ * Company, Team, and Subscription tabs.
+ */
+export default function SettingsSecondaryNav() {
+  const pathname = usePathname()
+
+  function isActive(href: string): boolean {
+    return pathname.startsWith(href)
+  }
+
+  return (
+    <nav className={styles.nav}>
+      {ITEMS.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          className={`${styles.item} ${isActive(item.href) ? styles.itemActive : ''}`}
+        >
+          {item.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/components/settings/CompanySettingsForm.module.css
+++ b/components/settings/CompanySettingsForm.module.css
@@ -1,0 +1,120 @@
+.container {
+  padding: var(--booking-pad-h);
+  max-width: 640px;
+}
+
+.heading {
+  font-size: var(--font-booking-title);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin-bottom: 4px;
+  color: var(--white);
+}
+
+.subHeading {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+  margin-bottom: 48px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fieldLabel {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+.fieldInput {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  color: var(--white);
+  font-family: inherit;
+  font-size: 20px;
+  font-weight: 400;
+  padding: 8px 0 12px;
+  caret-color: var(--accent);
+  transition: border-bottom-color 0.15s ease;
+}
+
+.fieldInput:focus {
+  outline: none;
+  border-bottom-color: var(--mid);
+}
+
+/* Logo upload placeholder */
+.logoUploadDisabled {
+  display: flex;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.logoUploadText {
+  font-size: var(--font-body);
+  font-weight: 300;
+  color: var(--mid);
+}
+
+/* Error banner */
+.errorBanner {
+  font-size: var(--font-body);
+  color: var(--repair);
+  border: 1px solid var(--repair);
+  padding: 12px 16px;
+}
+
+/* Success banner */
+.successBanner {
+  font-size: var(--font-body);
+  color: var(--accent);
+  border: 1px solid rgba(238, 204, 2, 0.3);
+  padding: 12px 16px;
+}
+
+/* Save button */
+.btnSave {
+  display: inline-block;
+  align-self: flex-start;
+  background: var(--accent);
+  color: var(--black);
+  border: none;
+  padding: 16px 40px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.btnSave:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.btnSave:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/components/settings/CompanySettingsForm.tsx
+++ b/components/settings/CompanySettingsForm.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { updateCompanyName } from '@/actions/company'
+import styles from './CompanySettingsForm.module.css'
+
+interface CompanySettingsFormProps {
+  name: string
+}
+
+export default function CompanySettingsForm({ name: initialName }: CompanySettingsFormProps) {
+  const [name, setName] = useState(initialName)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    setSuccess(false)
+
+    const result = await updateCompanyName(name)
+
+    setSubmitting(false)
+
+    if (result.error) {
+      setError(result.error)
+    } else {
+      setSuccess(true)
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.heading}>Settings</div>
+      <div className={styles.subHeading}>Company</div>
+
+      <form onSubmit={handleSubmit} className={styles.form}>
+        {/* Company name field */}
+        <div className={styles.fieldGroup}>
+          <label htmlFor="company-name" className={styles.fieldLabel}>
+            Company Name
+          </label>
+          <input
+            id="company-name"
+            type="text"
+            className={styles.fieldInput}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+              setSuccess(false)
+            }}
+            maxLength={100}
+            required
+          />
+        </div>
+
+        {/* Logo upload — coming soon */}
+        <div className={styles.fieldGroup}>
+          <span className={styles.fieldLabel}>Logo</span>
+          <div className={styles.logoUploadDisabled}>
+            <span className={styles.logoUploadText}>Logo upload coming soon</span>
+          </div>
+        </div>
+
+        {/* Error banner */}
+        {error && (
+          <div className={styles.errorBanner}>
+            {error}
+          </div>
+        )}
+
+        {/* Success banner */}
+        {success && (
+          <div className={styles.successBanner}>
+            Changes saved.
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className={styles.btnSave}
+          disabled={submitting}
+        >
+          {submitting ? 'Saving…' : 'Save Changes'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/components/settings/SubscriptionView.module.css
+++ b/components/settings/SubscriptionView.module.css
@@ -1,0 +1,152 @@
+.container {
+  padding: var(--booking-pad-h);
+  max-width: 800px;
+}
+
+.heading {
+  font-size: var(--font-booking-title);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin-bottom: 4px;
+  color: var(--white);
+}
+
+.subHeading {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+  margin-bottom: 40px;
+}
+
+/* No subscription state */
+.noSubscription {
+  padding: 24px 0;
+}
+
+.noSubText {
+  font-size: var(--font-body);
+  color: var(--mid);
+}
+
+/* Current plan block */
+.currentPlanBlock {
+  border: 1px solid rgba(238, 204, 2, 0.3);
+  padding: 28px 32px;
+  margin-bottom: 40px;
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.planBadge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--black);
+  padding: 6px 14px;
+  white-space: nowrap;
+}
+
+/* Status indicator */
+.planStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.statusDot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--mid);
+}
+
+.status_active    { background: var(--accent); }
+.status_trialing  { background: #c8a800; }
+.status_past_due  { background: var(--repair); }
+.status_canceled  { background: var(--mid); }
+
+.statusLabel {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+/* Plan details */
+.planDetails {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--mid);
+}
+
+.detailSep {
+  color: var(--dim);
+}
+
+/* Trial / renewal notices */
+.trialNotice {
+  margin-left: auto;
+  background: rgba(238, 204, 2, 0.08);
+  border: 1px solid rgba(238, 204, 2, 0.2);
+  padding: 10px 18px;
+  font-size: 11px;
+  color: #c8a800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.renewalNotice {
+  font-size: 12px;
+  font-weight: 300;
+  color: var(--mid);
+}
+
+/* Error banner */
+.errorBanner {
+  font-size: var(--font-body);
+  color: var(--repair);
+  border: 1px solid var(--repair);
+  padding: 12px 16px;
+  margin-bottom: 24px;
+}
+
+/* Manage button */
+.btnManage {
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--mid);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--dim);
+  padding-bottom: 2px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.btnManage:hover:not(:disabled) {
+  color: var(--white);
+  border-color: var(--mid);
+}
+
+.btnManage:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/components/settings/SubscriptionView.tsx
+++ b/components/settings/SubscriptionView.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useState } from 'react'
+import { createPortalSession } from '@/actions/subscription'
+import type { Subscription } from '@/types'
+import styles from './SubscriptionView.module.css'
+
+interface SubscriptionViewProps {
+  subscription: Subscription | null
+}
+
+const PLAN_LABELS: Record<string, string> = {
+  basic:      'Basic',
+  small:      'Small',
+  mid:        'Mid',
+  large:      'Large',
+  enterprise: 'Enterprise',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  trialing:  'Trial',
+  active:    'Active',
+  past_due:  'Past Due',
+  canceled:  'Canceled',
+}
+
+export default function SubscriptionView({ subscription }: SubscriptionViewProps) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleManage() {
+    setLoading(true)
+    setError(null)
+
+    const result = await createPortalSession()
+
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      setError(result.error)
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.heading}>Settings</div>
+      <div className={styles.subHeading}>Subscription</div>
+
+      {subscription === null ? (
+        <div className={styles.noSubscription}>
+          <p className={styles.noSubText}>No active subscription.</p>
+        </div>
+      ) : (
+        <>
+          {/* Current plan block */}
+          <div className={styles.currentPlanBlock}>
+            <span className={styles.planBadge}>
+              {PLAN_LABELS[subscription.plan] ?? subscription.plan}
+            </span>
+
+            <div className={styles.planStatus}>
+              <span className={`${styles.statusDot} ${styles[`status_${subscription.status}`]}`} />
+              <span className={styles.statusLabel}>
+                {STATUS_LABELS[subscription.status] ?? subscription.status}
+              </span>
+            </div>
+
+            <div className={styles.planDetails}>
+              <span>{subscription.limits.equipment} equipment items</span>
+              <span className={styles.detailSep}>·</span>
+              <span>{subscription.limits.users} members</span>
+            </div>
+
+            {subscription.status === 'trialing' && subscription.trialEnd && (
+              <div className={styles.trialNotice}>
+                Trial ends {formatDate(subscription.trialEnd)}
+              </div>
+            )}
+
+            {subscription.status !== 'trialing' && subscription.currentPeriodEnd && (
+              <div className={styles.renewalNotice}>
+                {subscription.cancelAtPeriodEnd
+                  ? `Cancels ${formatDate(subscription.currentPeriodEnd)}`
+                  : `Renews ${formatDate(subscription.currentPeriodEnd)}`}
+              </div>
+            )}
+          </div>
+
+          {/* Error banner */}
+          {error && (
+            <div className={styles.errorBanner}>
+              {error}
+            </div>
+          )}
+
+          {/* Manage billing */}
+          <button
+            className={styles.btnManage}
+            onClick={handleManage}
+            disabled={loading}
+            type="button"
+          >
+            {loading ? 'Redirecting…' : 'Manage Subscription'}
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}

--- a/components/settings/TeamSettingsView.module.css
+++ b/components/settings/TeamSettingsView.module.css
@@ -1,0 +1,207 @@
+.container {
+  padding: var(--booking-pad-h);
+  max-width: 800px;
+}
+
+.heading {
+  font-size: var(--font-booking-title);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  margin-bottom: 4px;
+  color: var(--white);
+}
+
+.subHeading {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+  margin-bottom: 32px;
+}
+
+/* Error banner */
+.errorBanner {
+  font-size: var(--font-body);
+  color: var(--repair);
+  border: 1px solid var(--repair);
+  padding: 12px 16px;
+  margin-bottom: 24px;
+}
+
+/* Section label */
+.sectionLabel {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 0;
+}
+
+/* Members table */
+.memberTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 48px;
+}
+
+.th {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--mid);
+  text-align: left;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.memberRow:hover .td,
+.memberRow:hover .tdAction {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 14px;
+  vertical-align: middle;
+}
+
+.tdAction {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rule);
+  vertical-align: middle;
+  text-align: right;
+  width: 80px;
+}
+
+/* Loading / empty states */
+.loadingState,
+.emptyState {
+  padding: 24px 0;
+  font-size: 14px;
+  color: var(--mid);
+}
+
+.memberName {
+  font-weight: 400;
+  color: var(--white);
+}
+
+.youTag {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1px solid rgba(238, 204, 2, 0.3);
+  padding: 2px 6px;
+  margin-left: 8px;
+}
+
+.roleText {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+.btnRemove {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--mid);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.btnRemove:hover {
+  color: var(--repair);
+}
+
+/* Invite section */
+.inviteSection {
+  border-top: 1px solid var(--rule);
+  padding-top: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.inviteLabel {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--mid);
+}
+
+.inviteForm {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--mid);
+  width: fit-content;
+}
+
+.inviteInput {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--white);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 300;
+  padding: 12px 16px;
+  width: 320px;
+  caret-color: var(--accent);
+}
+
+.inviteInput::placeholder {
+  color: var(--mid);
+}
+
+.btnInvite {
+  background: var(--dim);
+  color: var(--white);
+  border: none;
+  border-left: 1px solid var(--mid);
+  padding: 12px 20px;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.btnInvite:hover:not(:disabled) {
+  background: var(--mid);
+}
+
+.btnInvite:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.inviteNote {
+  font-size: 12px;
+  font-weight: 300;
+  color: var(--mid);
+}

--- a/components/settings/TeamSettingsView.tsx
+++ b/components/settings/TeamSettingsView.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useState } from 'react'
+import { useMembers } from '@/hooks/useMembers'
+import { inviteUser, removeMember } from '@/actions/team'
+import type { Role } from '@/types'
+import styles from './TeamSettingsView.module.css'
+
+interface TeamSettingsViewProps {
+  companyId: string
+  currentUserId: string
+}
+
+const ROLE_LABELS: Record<Role, string> = {
+  admin:  'Admin',
+  crew:   'Crew',
+  viewer: 'Viewer',
+}
+
+export default function TeamSettingsView({ companyId, currentUserId }: TeamSettingsViewProps) {
+  const { members, loading } = useMembers(companyId)
+
+  const [inviteEmail, setInviteEmail] = useState('')
+  const [inviting, setInviting] = useState(false)
+  const [inviteError, setInviteError] = useState<string | null>(null)
+
+  const [removeError, setRemoveError] = useState<string | null>(null)
+
+  async function handleInvite(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setInviting(true)
+    setInviteError(null)
+
+    const formData = new FormData()
+    formData.set('email', inviteEmail)
+
+    const result = await inviteUser(formData)
+
+    setInviting(false)
+
+    if (result.error) {
+      setInviteError(result.error)
+    } else {
+      setInviteEmail('')
+    }
+  }
+
+  async function handleRemove(memberId: string) {
+    setRemoveError(null)
+    const result = await removeMember(memberId)
+    if (result.error) {
+      setRemoveError(result.error)
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.heading}>Settings</div>
+      <div className={styles.subHeading}>Team</div>
+
+      {/* Error banner for remove actions */}
+      {removeError && (
+        <div className={styles.errorBanner}>
+          {removeError}
+        </div>
+      )}
+
+      {/* Members table */}
+      <div className={styles.sectionLabel}>Members</div>
+
+      {loading ? (
+        <div className={styles.loadingState}>Loading members…</div>
+      ) : members.length === 0 ? (
+        <div className={styles.emptyState}>No members found.</div>
+      ) : (
+        <table className={styles.memberTable}>
+          <thead>
+            <tr>
+              <th className={styles.th}>Name</th>
+              <th className={styles.th}>Role</th>
+              <th className={styles.th}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((member) => {
+              const isCurrentUser = member.uid === currentUserId
+              return (
+                <tr key={member.uid} className={styles.memberRow}>
+                  <td className={styles.td}>
+                    <span className={styles.memberName}>{member.name}</span>
+                    {isCurrentUser && (
+                      <span className={styles.youTag}>You</span>
+                    )}
+                  </td>
+                  <td className={styles.td}>
+                    <span className={styles.roleText}>
+                      {ROLE_LABELS[member.role] ?? member.role}
+                    </span>
+                  </td>
+                  <td className={styles.tdAction}>
+                    {!isCurrentUser && (
+                      <button
+                        className={styles.btnRemove}
+                        onClick={() => handleRemove(member.uid)}
+                        type="button"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {/* Invite section */}
+      <div className={styles.inviteSection}>
+        <span className={styles.inviteLabel}>Invite by Email</span>
+
+        {inviteError && (
+          <div className={styles.errorBanner}>
+            {inviteError}
+          </div>
+        )}
+
+        <form onSubmit={handleInvite} className={styles.inviteForm}>
+          <input
+            type="email"
+            className={styles.inviteInput}
+            placeholder="colleague@example.com"
+            value={inviteEmail}
+            onChange={(e) => {
+              setInviteEmail(e.target.value)
+              setInviteError(null)
+            }}
+            required
+          />
+          <button
+            type="submit"
+            className={styles.btnInvite}
+            disabled={inviting}
+          >
+            {inviting ? 'Sending…' : 'Send Invite'}
+          </button>
+        </form>
+
+        <p className={styles.inviteNote}>
+          Invited members will join as Crew by default.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,11 +17,20 @@
       ]
     },
     {
+      "collectionGroup": "equipment",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "active", "order": "ASCENDING" },
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "bookings",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "endDate", "order": "ASCENDING" },
-        { "fieldPath": "startDate", "order": "DESCENDING" }
+        { "fieldPath": "startDate", "order": "DESCENDING" },
+        { "fieldPath": "endDate", "order": "DESCENDING" }
       ]
     }
   ],

--- a/lib/queries/company.ts
+++ b/lib/queries/company.ts
@@ -4,6 +4,34 @@ import { cache } from 'react'
 import { adminDb } from '@/lib/firebase-admin'
 import type { Company } from '@/types'
 
+function docToCompany(doc: FirebaseFirestore.DocumentSnapshot): Company {
+  const data = doc.data() ?? {}
+
+  const subscription = data.subscription ?? {}
+  const mappedSubscription = {
+    status:             subscription.status             ?? 'trialing',
+    plan:               subscription.plan               ?? 'basic',
+    currentPeriodEnd:   subscription.currentPeriodEnd?.toDate?.()?.toISOString()
+                          ?? subscription.currentPeriodEnd
+                          ?? '',
+    limits:             subscription.limits             ?? { equipment: 0, users: 0 },
+    trialEnd:           subscription.trialEnd?.toDate?.()?.toISOString()
+                          ?? subscription.trialEnd
+                          ?? undefined,
+    cancelAtPeriodEnd:  subscription.cancelAtPeriodEnd  ?? undefined,
+    interval:           subscription.interval           ?? undefined,
+  }
+
+  return {
+    id:               doc.id,
+    name:             data.name             ?? '',
+    createdAt:        data.createdAt?.toDate?.()?.toISOString() ?? data.createdAt ?? '',
+    createdBy:        data.createdBy        ?? '',
+    stripeCustomerId: data.stripeCustomerId ?? '',
+    subscription:     mappedSubscription,
+  }
+}
+
 /**
  * Fetches a company document by ID.
  * Full implementation in Phase 2.
@@ -11,5 +39,5 @@ import type { Company } from '@/types'
 export const getCompany = cache(async (companyId: string): Promise<Company | null> => {
   const doc = await adminDb.collection('companies').doc(companyId).get()
   if (!doc.exists) return null
-  return { id: doc.id, ...doc.data() } as Company
+  return docToCompany(doc)
 })

--- a/lib/queries/equipment.ts
+++ b/lib/queries/equipment.ts
@@ -4,6 +4,24 @@ import { cache } from 'react'
 import { adminDb } from '@/lib/firebase-admin'
 import type { Equipment } from '@/types'
 
+function docToEquipment(doc: FirebaseFirestore.DocumentSnapshot): Equipment {
+  const data = doc.data() ?? {}
+  return {
+    id:               doc.id,
+    name:             data.name             ?? '',
+    category:         data.category         ?? '',
+    icon:             data.icon             ?? undefined,
+    active:           data.active           ?? true,
+    status:           data.status           ?? 'available',
+    trackingType:     data.trackingType     ?? 'individual',
+    totalQuantity:    data.totalQuantity    ?? 1,
+    serialNumber:     data.serialNumber     ?? null,
+    requiresApproval: data.requiresApproval ?? false,
+    approverId:       data.approverId       ?? null,
+    createdAt:        data.createdAt?.toDate?.()?.toISOString() ?? data.createdAt ?? null,
+  }
+}
+
 /**
  * Fetches active equipment for a company, sorted by category then name.
  * Wrapped in React.cache — multiple Server Components sharing the same
@@ -19,5 +37,5 @@ export const getEquipment = cache(async (companyId: string): Promise<Equipment[]
     .orderBy('name', 'asc')
     .get()
 
-  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() } as Equipment))
+  return snapshot.docs.map(docToEquipment)
 })

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -27,4 +27,5 @@ export interface Equipment {
   serialNumber: string | null // optional for individual; always null for quantity
   requiresApproval: boolean   // triggers approval flow when booked
   approverId: string | null   // specific user who must approve; Admin if null
+  createdAt: string | null    // ISO string (converted from Timestamp at read boundary)
 }


### PR DESCRIPTION
## Summary
- **#13/#14**: Add missing Firestore composite indexes for equipment (`active+category+name`) and bookings week view (`startDate DESC + endDate DESC`)
- **#15**: Build Settings section with Company, Team, and Subscription tabs
- **Auth fix**: Migrate all equipment/booking mutations from Cloud Functions to Server Actions with Admin SDK — fixes "You must be signed in" error caused by `httpsCallable` having no `auth.currentUser` on the server
- **Serialization fix**: Convert Firestore Timestamps to ISO strings in equipment and company queries

## Test plan
- [ ] Equipment page loads without FAILED_PRECONDITION
- [ ] New booking page loads equipment list
- [ ] Week/month view loads without FAILED_PRECONDITION
- [ ] Add/edit/deactivate equipment works without auth error
- [ ] Create/update/cancel/approve booking works
- [ ] Settings → Company: edit company name
- [ ] Settings → Team: view members
- [ ] Settings → Subscription: view plan
- [ ] Non-admin redirected from /settings to /bookings

🤖 Generated with [Claude Code](https://claude.com/claude-code)