### PR TITLE
fix(#51): unique key for booking items list

### DIFF
--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -164,10 +164,10 @@ export default function BookingDetail({
               Equipment ({booking.items.length})
             </div>
             <ul className={styles.itemList}>
-              {booking.items.map((item) => {
+              {booking.items.map((item, index) => {
                 const eq = findEquipment(item.equipmentId)
                 return (
-                  <li key={item.equipmentId} className={styles.item}>
+                  <li key={`${item.equipmentId}-${index}`} className={styles.item}>
                     <span className={styles.itemName}>
                       {eq?.name ?? item.equipmentId}
                     </span>


### PR DESCRIPTION
Fixes #51

Duplicate key warning when same equipment appeared multiple times in a booking. Uses `equipmentId-index` as key instead of `equipmentId` alone.