### PR TITLE
fix(#54): live active-link detection in PrimaryNav

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers'
 import { getVerifiedSession } from '@/lib/dal'
 import PrimaryNav from '@/components/nav/PrimaryNav'
 import { MobileBottomNav } from '@/components/nav/MobileBottomNav'
@@ -7,20 +6,14 @@ import styles from './app-layout.module.css'
 /**
  * Authenticated layout — Server Component.
  * Verifies session on every render; redirects to /login if invalid.
- * Renders PrimaryNav, passing serializable role and activePath.
- * LogoRow removed; each section now uses PageHeader.
+ * PrimaryNav is a Client Component and handles active-link detection itself.
  */
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const session = await getVerifiedSession()
 
-  // Read the current pathname from request headers so we can pass it as a
-  // serializable prop to the Server Component PrimaryNav (no usePathname needed).
-  const headersList = await headers()
-  const activePath = headersList.get('x-pathname') ?? '/'
-
   return (
     <div data-role={session.role} data-company={session.activeCompanyId}>
-      <PrimaryNav role={session.role} activePath={activePath} />
+      <PrimaryNav role={session.role} />
       <main className={styles.main}>
         {children}
       </main>

--- a/components/nav/PrimaryNav.tsx
+++ b/components/nav/PrimaryNav.tsx
@@ -1,19 +1,21 @@
+'use client'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import type { Role } from '@/types'
 import styles from './PrimaryNav.module.css'
 
 interface PrimaryNavProps {
   role: Role
-  activePath: string
 }
 
 /**
- * Primary navigation — Server Component.
- * Receives role and activePath as serializable props from the app layout.
+ * Primary navigation — Client Component.
+ * Uses usePathname() for live active-link detection on client-side navigation.
  * Role controls visibility of the Settings link.
  */
-export default function PrimaryNav({ role, activePath }: PrimaryNavProps) {
-  const isActive = (path: string) => activePath.startsWith(path)
+export default function PrimaryNav({ role }: PrimaryNavProps) {
+  const pathname = usePathname()
+  const isActive = (path: string) => pathname.startsWith(path)
 
   return (
     <nav className={styles.nav}>


### PR DESCRIPTION
Fixes #54

PrimaryNav was a Server Component receiving activePath as a static prop — it didn't update on client-side navigation. Converted to Client Component using usePathname(), same pattern as MobileBottomNav.