### PR TITLE
fix(#45): constrain equipment view width to 800px

### DIFF
--- a/app/(app)/equipment/equipment-layout.module.css
+++ b/app/(app)/equipment/equipment-layout.module.css
@@ -1,0 +1,5 @@
+.contentWidth {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/(app)/equipment/layout.tsx
+++ b/app/(app)/equipment/layout.tsx
@@ -1,0 +1,9 @@
+import styles from './equipment-layout.module.css'
+
+export default function EquipmentLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className={styles.contentWidth}>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
Fixes #45

Add layout.tsx for the equipment section with max-width: 800px, matching the bookings view.