### PR TITLE
feat(#50): saving overlay with dimmed background

### DIFF
--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { createBooking, checkConflict } from '@/actions/bookings'
+import { useToast } from '@/lib/toast-context'
 import type { Equipment, BookingItem } from '@/types'
 import type { ConflictResult } from '@/actions/bookings'
 import styles from './BookingForm.module.css'
@@ -46,6 +47,7 @@ export default function BookingForm({
   defaultEndDate,
 }: BookingFormProps) {
   const router = useRouter()
+  const { showToast, dismissToast } = useToast()
 
   const [projectName, setProjectName]   = useState('')
   const [startDate, setStartDate]       = useState(defaultStartDate)
@@ -199,11 +201,15 @@ export default function BookingForm({
     formData.set('notes', notes)
     formData.set('items', JSON.stringify(selectedItems))
 
+    const toastId = showToast('saving', 'Saving booking...')
     startTransition(async () => {
       const result = await createBooking(formData)
+      dismissToast(toastId)
       if ('error' in result) {
         setError(result.error)
+        showToast('error', result.error, 5000)
       } else {
+        showToast('success', 'Booking created', 3000)
         router.push(`/bookings/${result.bookingId}`)
       }
     })

--- a/components/ui/Toast.module.css
+++ b/components/ui/Toast.module.css
@@ -1,0 +1,80 @@
+.container {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  pointer-events: all;
+  white-space: nowrap;
+}
+
+.saving {
+  background: var(--surface-container-low);
+  color: var(--on-surface-variant);
+  border: 1px solid var(--outline-variant);
+}
+
+.success {
+  background: var(--white);
+  color: var(--black);
+}
+
+.error {
+  background: var(--repair);
+  color: var(--white);
+}
+
+.message {
+  flex: 1;
+}
+
+.dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 0.65rem;
+  padding: 0;
+  opacity: 0.6;
+  line-height: 1;
+}
+
+.dismiss:hover {
+  opacity: 1;
+}
+
+/* Spinning dot indicator for saving state */
+.spinner {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--on-surface-variant);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+@media (max-width: 768px) {
+  .container {
+    bottom: 100px;
+  }
+}

--- a/components/ui/Toast.module.css
+++ b/components/ui/Toast.module.css
@@ -1,3 +1,31 @@
+/* ── Saving overlay — full screen, dims background ─────────────────────────── */
+
+.savingOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 8, 8, 0.88);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.savingBox {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 32px;
+  background: var(--surface-container-low);
+  border: 1px solid var(--outline-variant);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--on-surface-variant);
+}
+
+/* ── Inline toasts (success / error) ────────────────────────────────────────── */
+
 .container {
   position: fixed;
   bottom: 32px;
@@ -22,12 +50,6 @@
   text-transform: uppercase;
   pointer-events: all;
   white-space: nowrap;
-}
-
-.saving {
-  background: var(--surface-container-low);
-  color: var(--on-surface-variant);
-  border: 1px solid var(--outline-variant);
 }
 
 .success {
@@ -59,7 +81,7 @@
   opacity: 1;
 }
 
-/* Spinning dot indicator for saving state */
+/* Pulsing dot for saving state */
 .spinner {
   width: 6px;
   height: 6px;

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { useToast } from '@/lib/toast-context'
+import styles from './Toast.module.css'
+
+export function ToastContainer() {
+  const { toasts, dismissToast } = useToast()
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className={styles.container}>
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`${styles.toast} ${styles[toast.type]}`}>
+          {toast.type === 'saving' && <span className={styles.spinner} />}
+          <span className={styles.message}>{toast.message}</span>
+          {toast.type !== 'saving' && (
+            <button className={styles.dismiss} onClick={() => dismissToast(toast.id)}>
+              ✕
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -6,21 +6,34 @@ import styles from './Toast.module.css'
 export function ToastContainer() {
   const { toasts, dismissToast } = useToast()
 
-  if (toasts.length === 0) return null
+  const savingToast = toasts.find((t) => t.type === 'saving')
+  const inlineToasts = toasts.filter((t) => t.type !== 'saving')
 
   return (
-    <div className={styles.container}>
-      {toasts.map((toast) => (
-        <div key={toast.id} className={`${styles.toast} ${styles[toast.type]}`}>
-          {toast.type === 'saving' && <span className={styles.spinner} />}
-          <span className={styles.message}>{toast.message}</span>
-          {toast.type !== 'saving' && (
-            <button className={styles.dismiss} onClick={() => dismissToast(toast.id)}>
-              ✕
-            </button>
-          )}
+    <>
+      {/* Saving overlay — dims background and centers message */}
+      {savingToast && (
+        <div className={styles.savingOverlay}>
+          <div className={styles.savingBox}>
+            <span className={styles.spinner} />
+            <span>{savingToast.message}</span>
+          </div>
         </div>
-      ))}
-    </div>
+      )}
+
+      {/* Success / error toasts — bottom center, no overlay */}
+      {inlineToasts.length > 0 && (
+        <div className={styles.container}>
+          {inlineToasts.map((toast) => (
+            <div key={toast.id} className={`${styles.toast} ${styles[toast.type]}`}>
+              <span className={styles.message}>{toast.message}</span>
+              <button className={styles.dismiss} onClick={() => dismissToast(toast.id)}>
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
   )
 }

--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -1,7 +1,16 @@
 'use client'
 
 import { AuthProvider } from '@/lib/auth-context'
+import { ToastProvider } from '@/lib/toast-context'
+import { ToastContainer } from '@/components/ui/Toast'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>
+  return (
+    <AuthProvider>
+      <ToastProvider>
+        {children}
+        <ToastContainer />
+      </ToastProvider>
+    </AuthProvider>
+  )
 }

--- a/lib/toast-context.tsx
+++ b/lib/toast-context.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { createContext, useContext, useState, useCallback, useRef } from 'react'
+
+export type ToastType = 'saving' | 'success' | 'error'
+
+export interface Toast {
+  id: number
+  type: ToastType
+  message: string
+}
+
+interface ToastContextValue {
+  toasts: Toast[]
+  showToast: (type: ToastType, message: string, autoDismissMs?: number) => number
+  dismissToast: (id: number) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const counter = useRef(0)
+
+  const dismissToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const showToast = useCallback(
+    (type: ToastType, message: string, autoDismissMs?: number): number => {
+      const id = ++counter.current
+      setToasts((prev) => [...prev, { id, type, message }])
+      if (autoDismissMs) {
+        setTimeout(() => dismissToast(id), autoDismissMs)
+      }
+      return id
+    },
+    [dismissToast],
+  )
+
+  return (
+    <ToastContext.Provider value={{ toasts, showToast, dismissToast }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider')
+  return ctx
+}


### PR DESCRIPTION
Fixes #50

Add global ToastProvider/useToast system. Saving state renders as a full-screen overlay that dims the background and centers the message — same overlay pattern as modals. Success/error render as small inline toasts at bottom center.