### PR TITLE
feat(#48): custom fields on equipment, remove condition

### DIFF
--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -4,7 +4,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { revalidatePath } from 'next/cache'
 import { adminDb } from '@/lib/firebase-admin'
 import { getVerifiedSession } from '@/lib/dal'
-import type { Subscription, UnitCondition, EquipmentStatus } from '@/types'
+import type { Subscription, EquipmentStatus } from '@/types'
 
 // ── Internal Firestore document shapes ──────────────────────────────────────
 
@@ -53,6 +53,9 @@ export async function createEquipment(
   const requiresApproval = formData.get('requiresApproval') === 'true'
   const approverIdRaw = formData.get('approverId') as string | null
   const approverId: string | null = approverIdRaw?.trim() || null
+
+  const customFieldsRaw = formData.get('customFields') as string | null
+  const customFields = customFieldsRaw ? JSON.parse(customFieldsRaw) : []
 
   // ── Transaction: check plan limit + write atomically ──────────────────────
   let newEquipmentId: string
@@ -110,6 +113,7 @@ export async function createEquipment(
         active: true,
         requiresApproval,
         approverId,
+        customFields,
         createdAt: FieldValue.serverTimestamp(),
         createdBy: session.uid,
       })
@@ -189,6 +193,11 @@ export async function updateEquipment(
   const rawApproverId = formData.get('approverId') as string | null
   if (rawApproverId !== null) {
     updates['approverId'] = rawApproverId.trim() || null
+  }
+
+  const rawCustomFields = formData.get('customFields') as string | null
+  if (rawCustomFields !== null) {
+    updates['customFields'] = JSON.parse(rawCustomFields)
   }
 
   const rawTotalQuantity = formData.get('totalQuantity')
@@ -319,11 +328,6 @@ export async function createUnit(
   if (label.length > 100) return { error: 'Label must be 100 characters or fewer.' }
 
   const serialNumber = (formData.get('serialNumber') as string | null)?.trim() || null
-  const VALID_CONDITIONS = ['new', 'good', 'fair', 'poor'] as const
-  const conditionRaw = formData.get('condition') as string | null
-  const condition: UnitCondition = (VALID_CONDITIONS as readonly string[]).includes(conditionRaw ?? '')
-    ? (conditionRaw as UnitCondition)
-    : 'good'
   const notes = (formData.get('notes') as string | null)?.trim() || null
 
   const unitRef = parentRef.collection('units').doc()
@@ -333,7 +337,6 @@ export async function createUnit(
     label,
     serialNumber,
     status: 'available',
-    condition,
     notes,
     active: true,
     createdAt: FieldValue.serverTimestamp(),
@@ -363,16 +366,13 @@ export async function updateUnit(
   if (!label) return { error: 'Label is required.' }
 
   const VALID_STATUSES: EquipmentStatus[] = ['available', 'checked_out', 'needs_repair']
-  const VALID_CONDITIONS: UnitCondition[] = ['new', 'good', 'fair', 'poor']
 
   const statusRaw = formData.get('status') as string | null
-  const conditionRaw = formData.get('condition') as string | null
 
   await unitRef.update({
     label,
     serialNumber: (formData.get('serialNumber') as string | null)?.trim() || null,
     status: VALID_STATUSES.includes(statusRaw as EquipmentStatus) ? statusRaw : 'available',
-    condition: VALID_CONDITIONS.includes(conditionRaw as UnitCondition) ? conditionRaw : 'good',
     notes: (formData.get('notes') as string | null)?.trim() || null,
     updatedAt: FieldValue.serverTimestamp(),
     updatedBy: session.uid,

--- a/components/equipment/EquipmentForm.module.css
+++ b/components/equipment/EquipmentForm.module.css
@@ -206,3 +206,63 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* ── Custom Fields ─────────────────────────────────────────────────────────── */
+
+.customFieldsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.addFieldBtn {
+  font-size: var(--font-subnav);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--mid);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s ease;
+}
+
+.addFieldBtn:hover {
+  color: var(--white);
+}
+
+.customFieldRow {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.customFieldRow .input,
+.customFieldRow .select {
+  flex: 1;
+  min-width: 0;
+}
+
+.customFieldRangeSep {
+  color: var(--mid);
+  font-weight: 300;
+  padding-bottom: 8px;
+  flex-shrink: 0;
+}
+
+.removeFieldBtn {
+  background: none;
+  border: none;
+  color: var(--mid);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 0 8px 0;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+
+.removeFieldBtn:hover {
+  color: var(--repair);
+}

--- a/components/equipment/EquipmentForm.tsx
+++ b/components/equipment/EquipmentForm.tsx
@@ -144,6 +144,91 @@ export default function EquipmentForm({
         />
       </div>
 
+      {/* Custom Fields */}
+      <div className={styles.field}>
+        <div className={styles.customFieldsHeader}>
+          <span className={styles.label}>Custom Fields</span>
+          <button type="button" onClick={addField} className={styles.addFieldBtn}>
+            + Add field
+          </button>
+        </div>
+
+        {customFields.map((field) => (
+          <div key={field.id} className={styles.customFieldRow}>
+            <input
+              type="text"
+              value={field.label}
+              onChange={(e) => updateField(field.id, { label: e.target.value })}
+              placeholder="Label"
+              className={styles.input}
+            />
+            <select
+              value={field.type}
+              onChange={(e) => handleTypeChange(field.id, e.target.value as CustomFieldType)}
+              className={styles.select}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="range">Range</option>
+            </select>
+            {field.type === 'text' && (
+              <input
+                type="text"
+                value={field.value as string}
+                onChange={(e) => updateField(field.id, { value: e.target.value })}
+                placeholder="Value"
+                className={styles.input}
+              />
+            )}
+            {field.type === 'number' && (
+              <input
+                type="number"
+                value={field.value as number}
+                onChange={(e) => updateField(field.id, { value: parseFloat(e.target.value) || 0 })}
+                placeholder="Value"
+                className={styles.input}
+              />
+            )}
+            {field.type === 'range' && (
+              <>
+                <input
+                  type="number"
+                  value={(field.value as { min: number; max: number | null }).min}
+                  onChange={(e) =>
+                    updateField(field.id, {
+                      value: { ...(field.value as { min: number; max: number | null }), min: parseFloat(e.target.value) || 0 },
+                    })
+                  }
+                  placeholder="Min"
+                  className={styles.input}
+                />
+                <span className={styles.customFieldRangeSep}>–</span>
+                <input
+                  type="number"
+                  value={(field.value as { min: number; max: number | null }).max ?? ''}
+                  onChange={(e) => {
+                    const raw = e.target.value
+                    updateField(field.id, {
+                      value: { ...(field.value as { min: number; max: number | null }), max: raw === '' ? null : parseFloat(raw) || 0 },
+                    })
+                  }}
+                  placeholder="Max (optional)"
+                  className={styles.input}
+                />
+              </>
+            )}
+            <button
+              type="button"
+              onClick={() => removeField(field.id)}
+              className={styles.removeFieldBtn}
+              aria-label="Remove field"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+
       {/* Tracking type — immutable after creation */}
       <div className={styles.field}>
         <label className={styles.label}>
@@ -259,98 +344,6 @@ export default function EquipmentForm({
           </div>
         </div>
       )}
-
-      {/* Custom Fields */}
-      <div className={styles.field}>
-        <div className={styles.customFieldsHeader}>
-          <span className={styles.label}>Custom Fields</span>
-          <button type="button" onClick={addField} className={styles.addFieldBtn}>
-            + Add field
-          </button>
-        </div>
-
-        {customFields.map((field) => (
-          <div key={field.id} className={styles.customFieldRow}>
-            {/* Label */}
-            <input
-              type="text"
-              value={field.label}
-              onChange={(e) => updateField(field.id, { label: e.target.value })}
-              placeholder="Label"
-              className={styles.input}
-            />
-
-            {/* Type */}
-            <select
-              value={field.type}
-              onChange={(e) => handleTypeChange(field.id, e.target.value as CustomFieldType)}
-              className={styles.select}
-            >
-              <option value="text">Text</option>
-              <option value="number">Number</option>
-              <option value="range">Range</option>
-            </select>
-
-            {/* Value input(s) */}
-            {field.type === 'text' && (
-              <input
-                type="text"
-                value={field.value as string}
-                onChange={(e) => updateField(field.id, { value: e.target.value })}
-                placeholder="Value"
-                className={styles.input}
-              />
-            )}
-            {field.type === 'number' && (
-              <input
-                type="number"
-                value={field.value as number}
-                onChange={(e) => updateField(field.id, { value: parseFloat(e.target.value) || 0 })}
-                placeholder="Value"
-                className={styles.input}
-              />
-            )}
-            {field.type === 'range' && (
-              <>
-                <input
-                  type="number"
-                  value={(field.value as { min: number; max: number | null }).min}
-                  onChange={(e) =>
-                    updateField(field.id, {
-                      value: { ...(field.value as { min: number; max: number | null }), min: parseFloat(e.target.value) || 0 },
-                    })
-                  }
-                  placeholder="Min"
-                  className={styles.input}
-                />
-                <span className={styles.customFieldRangeSep}>–</span>
-                <input
-                  type="number"
-                  value={(field.value as { min: number; max: number | null }).max ?? ''}
-                  onChange={(e) => {
-                    const raw = e.target.value
-                    updateField(field.id, {
-                      value: { ...(field.value as { min: number; max: number | null }), max: raw === '' ? null : parseFloat(raw) || 0 },
-                    })
-                  }}
-                  placeholder="Max (optional)"
-                  className={styles.input}
-                />
-              </>
-            )}
-
-            {/* Remove */}
-            <button
-              type="button"
-              onClick={() => removeField(field.id)}
-              className={styles.removeFieldBtn}
-              aria-label="Remove field"
-            >
-              ✕
-            </button>
-          </div>
-        ))}
-      </div>
 
       {/* Error message */}
       {error && <p className={styles.error}>{error}</p>}

--- a/components/equipment/EquipmentForm.tsx
+++ b/components/equipment/EquipmentForm.tsx
@@ -5,7 +5,7 @@ import { createEquipment, updateEquipment } from '@/actions/equipment'
 import { useCategories } from '@/hooks/useCategories'
 import { useMembers } from '@/hooks/useMembers'
 import { useAuth } from '@/lib/auth-context'
-import type { Equipment, TrackingType } from '@/types'
+import type { Equipment, TrackingType, CustomField, CustomFieldType } from '@/types'
 import styles from './EquipmentForm.module.css'
 
 interface EquipmentFormProps {
@@ -32,6 +32,7 @@ export default function EquipmentForm({
   const [totalQuantity, setTotalQuantity] = useState(equipment?.totalQuantity ?? 1)
   const [requiresApproval, setRequiresApproval] = useState(equipment?.requiresApproval ?? false)
   const [approverId, setApproverId] = useState(equipment?.approverId ?? '')
+  const [customFields, setCustomFields] = useState<CustomField[]>(equipment?.customFields ?? [])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const nameRef = useRef<HTMLInputElement>(null)
@@ -42,6 +43,31 @@ export default function EquipmentForm({
   useEffect(() => {
     nameRef.current?.focus()
   }, [])
+
+  function addField() {
+    setCustomFields(prev => [...prev, {
+      id: Math.random().toString(36).slice(2, 8),
+      label: '',
+      type: 'text',
+      value: '',
+    }])
+  }
+
+  function removeField(id: string) {
+    setCustomFields(prev => prev.filter(f => f.id !== id))
+  }
+
+  function updateField(id: string, patch: Partial<CustomField>) {
+    setCustomFields(prev => prev.map(f => f.id === id ? { ...f, ...patch } as CustomField : f))
+  }
+
+  function handleTypeChange(id: string, newType: CustomFieldType) {
+    let value: CustomField['value']
+    if (newType === 'text') value = ''
+    else if (newType === 'number') value = 0
+    else value = { min: 0, max: null }
+    updateField(id, { type: newType, value } as Partial<CustomField>)
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -56,6 +82,7 @@ export default function EquipmentForm({
     formData.set('category', category)
     formData.set('requiresApproval', String(requiresApproval))
     formData.set('approverId', approverId)
+    formData.set('customFields', JSON.stringify(customFields))
     if (!isEditMode) {
       formData.set('trackingType', trackingType)
     }
@@ -232,6 +259,98 @@ export default function EquipmentForm({
           </div>
         </div>
       )}
+
+      {/* Custom Fields */}
+      <div className={styles.field}>
+        <div className={styles.customFieldsHeader}>
+          <span className={styles.label}>Custom Fields</span>
+          <button type="button" onClick={addField} className={styles.addFieldBtn}>
+            + Add field
+          </button>
+        </div>
+
+        {customFields.map((field) => (
+          <div key={field.id} className={styles.customFieldRow}>
+            {/* Label */}
+            <input
+              type="text"
+              value={field.label}
+              onChange={(e) => updateField(field.id, { label: e.target.value })}
+              placeholder="Label"
+              className={styles.input}
+            />
+
+            {/* Type */}
+            <select
+              value={field.type}
+              onChange={(e) => handleTypeChange(field.id, e.target.value as CustomFieldType)}
+              className={styles.select}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="range">Range</option>
+            </select>
+
+            {/* Value input(s) */}
+            {field.type === 'text' && (
+              <input
+                type="text"
+                value={field.value as string}
+                onChange={(e) => updateField(field.id, { value: e.target.value })}
+                placeholder="Value"
+                className={styles.input}
+              />
+            )}
+            {field.type === 'number' && (
+              <input
+                type="number"
+                value={field.value as number}
+                onChange={(e) => updateField(field.id, { value: parseFloat(e.target.value) || 0 })}
+                placeholder="Value"
+                className={styles.input}
+              />
+            )}
+            {field.type === 'range' && (
+              <>
+                <input
+                  type="number"
+                  value={(field.value as { min: number; max: number | null }).min}
+                  onChange={(e) =>
+                    updateField(field.id, {
+                      value: { ...(field.value as { min: number; max: number | null }), min: parseFloat(e.target.value) || 0 },
+                    })
+                  }
+                  placeholder="Min"
+                  className={styles.input}
+                />
+                <span className={styles.customFieldRangeSep}>–</span>
+                <input
+                  type="number"
+                  value={(field.value as { min: number; max: number | null }).max ?? ''}
+                  onChange={(e) => {
+                    const raw = e.target.value
+                    updateField(field.id, {
+                      value: { ...(field.value as { min: number; max: number | null }), max: raw === '' ? null : parseFloat(raw) || 0 },
+                    })
+                  }}
+                  placeholder="Max (optional)"
+                  className={styles.input}
+                />
+              </>
+            )}
+
+            {/* Remove */}
+            <button
+              type="button"
+              onClick={() => removeField(field.id)}
+              className={styles.removeFieldBtn}
+              aria-label="Remove field"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
 
       {/* Error message */}
       {error && <p className={styles.error}>{error}</p>}

--- a/components/equipment/EquipmentForm.tsx
+++ b/components/equipment/EquipmentForm.tsx
@@ -62,10 +62,7 @@ export default function EquipmentForm({
   }
 
   function handleTypeChange(id: string, newType: CustomFieldType) {
-    let value: CustomField['value']
-    if (newType === 'text') value = ''
-    else if (newType === 'number') value = 0
-    else value = { min: 0, max: null }
+    const value = newType === 'text' ? '' : { min: 0, max: null }
     updateField(id, { type: newType, value } as Partial<CustomField>)
   }
 
@@ -168,8 +165,7 @@ export default function EquipmentForm({
               className={styles.select}
             >
               <option value="text">Text</option>
-              <option value="number">Number</option>
-              <option value="range">Range</option>
+              <option value="value">Value</option>
             </select>
             {field.type === 'text' && (
               <input
@@ -180,16 +176,7 @@ export default function EquipmentForm({
                 className={styles.input}
               />
             )}
-            {field.type === 'number' && (
-              <input
-                type="number"
-                value={field.value as number}
-                onChange={(e) => updateField(field.id, { value: parseFloat(e.target.value) || 0 })}
-                placeholder="Value"
-                className={styles.input}
-              />
-            )}
-            {field.type === 'range' && (
+            {field.type === 'value' && (
               <>
                 <input
                   type="number"

--- a/components/equipment/UnitForm.tsx
+++ b/components/equipment/UnitForm.tsx
@@ -53,16 +53,6 @@ export function UnitForm({ equipmentId, unit, onSuccess }: UnitFormProps) {
       )}
 
       <div className={styles.field}>
-        <label className={styles.label}>Condition</label>
-        <select name="condition" className={styles.input} defaultValue={unit?.condition ?? 'good'}>
-          <option value="new">New</option>
-          <option value="good">Good</option>
-          <option value="fair">Fair</option>
-          <option value="poor">Poor</option>
-        </select>
-      </div>
-
-      <div className={styles.field}>
         <label className={styles.label}>Notes</label>
         <textarea name="notes" className={styles.input} defaultValue={unit?.notes ?? ''} rows={3} />
       </div>

--- a/functions/src/equipment/addEquipment.ts
+++ b/functions/src/equipment/addEquipment.ts
@@ -2,6 +2,7 @@ import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
 import { CompanyDocument } from '../types';
+import { validateCustomFields } from './validateCustomFields';
 
 /**
  * Adds a new equipment item to a company's inventory.
@@ -92,6 +93,8 @@ export const addEquipment = onCall({ region: 'europe-west1', cors: true, invoker
       ? null
       : String(rawApproverId);
 
+  const customFields = validateCustomFields(request.data.customFields);
+
   // ── trackingType validation ────────────────────────────────────────────────
   const VALID_TRACKING_TYPES = ['serialized', 'quantity'] as const;
   type TrackingType = typeof VALID_TRACKING_TYPES[number];
@@ -179,6 +182,7 @@ export const addEquipment = onCall({ region: 'europe-west1', cors: true, invoker
       active: true,
       requiresApproval,
       approverId,
+      customFields,
       createdAt: FieldValue.serverTimestamp(),
       createdBy: request.auth!.uid,
     });

--- a/functions/src/equipment/updateEquipment.ts
+++ b/functions/src/equipment/updateEquipment.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { logger } from 'firebase-functions/v2';
 import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { validateCustomFields } from './validateCustomFields';
 
 /**
  * Updates fields on an existing equipment document.
@@ -134,6 +135,10 @@ export const updateEquipment = onCall({ region: 'europe-west1', cors: true, invo
       // TODO Phase 3: reject if rawQty < max concurrently booked quantity
       updates['totalQuantity'] = rawQty;
     }
+  }
+
+  if (request.data.customFields !== undefined) {
+    updates['customFields'] = validateCustomFields(request.data.customFields);
   }
 
   // ── serialNumber — only valid for serialized items ────────────────────────

--- a/functions/src/equipment/validateCustomFields.ts
+++ b/functions/src/equipment/validateCustomFields.ts
@@ -1,0 +1,68 @@
+import { HttpsError } from 'firebase-functions/v2/https';
+
+const MAX_CUSTOM_FIELDS = 20;
+const MAX_LABEL_LENGTH = 100;
+const VALID_TYPES = ['text', 'number', 'range'] as const;
+type FieldType = typeof VALID_TYPES[number];
+
+interface CustomFieldText { id: string; label: string; type: 'text'; value: string }
+interface CustomFieldNumber { id: string; label: string; type: 'number'; value: number }
+interface CustomFieldRange { id: string; label: string; type: 'range'; value: { min: number; max: number | null } }
+type CustomField = CustomFieldText | CustomFieldNumber | CustomFieldRange;
+
+export function validateCustomFields(raw: unknown): CustomField[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    throw new HttpsError('invalid-argument', 'customFields must be an array.');
+  }
+  if (raw.length > MAX_CUSTOM_FIELDS) {
+    throw new HttpsError('invalid-argument', `Maximum ${MAX_CUSTOM_FIELDS} custom fields allowed.`);
+  }
+
+  return raw.map((field, i): CustomField => {
+    if (typeof field !== 'object' || field === null) {
+      throw new HttpsError('invalid-argument', `customFields[${i}] must be an object.`);
+    }
+    const { id, label, type, value } = field as Record<string, unknown>;
+
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].id must be a non-empty string.`);
+    }
+    if (typeof label !== 'string' || label.trim().length === 0) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].label is required.`);
+    }
+    if (label.trim().length > MAX_LABEL_LENGTH) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].label must be ${MAX_LABEL_LENGTH} characters or fewer.`);
+    }
+    if (!VALID_TYPES.includes(type as FieldType)) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].type must be one of: ${VALID_TYPES.join(', ')}.`);
+    }
+
+    if (type === 'text') {
+      if (typeof value !== 'string') {
+        throw new HttpsError('invalid-argument', `customFields[${i}].value must be a string for type "text".`);
+      }
+      return { id: id.trim(), label: label.trim(), type: 'text', value };
+    }
+
+    if (type === 'number') {
+      if (typeof value !== 'number' || !isFinite(value)) {
+        throw new HttpsError('invalid-argument', `customFields[${i}].value must be a finite number for type "number".`);
+      }
+      return { id: id.trim(), label: label.trim(), type: 'number', value };
+    }
+
+    // range
+    if (typeof value !== 'object' || value === null) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].value must be an object {min, max} for type "range".`);
+    }
+    const { min, max } = value as Record<string, unknown>;
+    if (typeof min !== 'number' || !isFinite(min)) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].value.min must be a finite number.`);
+    }
+    if (max !== null && (typeof max !== 'number' || !isFinite(max))) {
+      throw new HttpsError('invalid-argument', `customFields[${i}].value.max must be a finite number or null.`);
+    }
+    return { id: id.trim(), label: label.trim(), type: 'range', value: { min, max: max ?? null } };
+  });
+}

--- a/functions/src/equipment/validateCustomFields.ts
+++ b/functions/src/equipment/validateCustomFields.ts
@@ -2,13 +2,12 @@ import { HttpsError } from 'firebase-functions/v2/https';
 
 const MAX_CUSTOM_FIELDS = 20;
 const MAX_LABEL_LENGTH = 100;
-const VALID_TYPES = ['text', 'number', 'range'] as const;
+const VALID_TYPES = ['text', 'value'] as const;
 type FieldType = typeof VALID_TYPES[number];
 
 interface CustomFieldText { id: string; label: string; type: 'text'; value: string }
-interface CustomFieldNumber { id: string; label: string; type: 'number'; value: number }
-interface CustomFieldRange { id: string; label: string; type: 'range'; value: { min: number; max: number | null } }
-type CustomField = CustomFieldText | CustomFieldNumber | CustomFieldRange;
+interface CustomFieldValue { id: string; label: string; type: 'value'; value: { min: number; max: number | null } }
+type CustomField = CustomFieldText | CustomFieldValue;
 
 export function validateCustomFields(raw: unknown): CustomField[] {
   if (raw === undefined || raw === null) return [];
@@ -45,16 +44,9 @@ export function validateCustomFields(raw: unknown): CustomField[] {
       return { id: id.trim(), label: label.trim(), type: 'text', value };
     }
 
-    if (type === 'number') {
-      if (typeof value !== 'number' || !isFinite(value)) {
-        throw new HttpsError('invalid-argument', `customFields[${i}].value must be a finite number for type "number".`);
-      }
-      return { id: id.trim(), label: label.trim(), type: 'number', value };
-    }
-
-    // range
+    // value (single number or range)
     if (typeof value !== 'object' || value === null) {
-      throw new HttpsError('invalid-argument', `customFields[${i}].value must be an object {min, max} for type "range".`);
+      throw new HttpsError('invalid-argument', `customFields[${i}].value must be an object {min, max} for type "value".`);
     }
     const { min, max } = value as Record<string, unknown>;
     if (typeof min !== 'number' || !isFinite(min)) {
@@ -63,6 +55,6 @@ export function validateCustomFields(raw: unknown): CustomField[] {
     if (max !== null && (typeof max !== 'number' || !isFinite(max))) {
       throw new HttpsError('invalid-argument', `customFields[${i}].value.max must be a finite number or null.`);
     }
-    return { id: id.trim(), label: label.trim(), type: 'range', value: { min, max: max ?? null } };
+    return { id: id.trim(), label: label.trim(), type: 'value', value: { min, max: max ?? null } };
   });
 }

--- a/lib/queries/equipment.ts
+++ b/lib/queries/equipment.ts
@@ -18,6 +18,7 @@ function docToEquipment(doc: FirebaseFirestore.DocumentSnapshot): Equipment {
     requiresApproval: data.requiresApproval ?? false,
     approverId:       data.approverId       ?? null,
     createdAt:        data.createdAt?.toDate?.()?.toISOString() ?? data.createdAt ?? null,
+    customFields:     Array.isArray(data.customFields) ? data.customFields : [],
   }
 }
 
@@ -30,7 +31,6 @@ function docToUnit(doc: FirebaseFirestore.DocumentSnapshot): EquipmentUnit {
     label:        data.label        ?? '',
     serialNumber: data.serialNumber ?? null,
     status:       data.status       ?? 'available',
-    condition:    data.condition    ?? 'good',
     notes:        data.notes        ?? null,
     active:       data.active       ?? true,
     createdAt:    data.createdAt?.toDate?.()?.toISOString() ?? data.createdAt ?? null,

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -3,12 +3,35 @@ export type EquipmentStatus = 'available' | 'checked_out' | 'needs_repair'
 // 'serialized' = one parent doc per equipment type, one subcollection doc per physical unit
 // 'quantity'   = one document represents a pool of interchangeable items
 export type TrackingType = 'serialized' | 'quantity'
-export type UnitCondition = 'new' | 'good' | 'fair' | 'poor'
 
 // Default categories seeded for every new company
 export const DEFAULT_EQUIPMENT_CATEGORIES = [
   'Camera', 'Lenses', 'Audio', 'Lighting', 'Grip', 'Accessories',
 ] as const
+
+export interface CustomFieldText {
+  id: string
+  label: string
+  type: 'text'
+  value: string
+}
+
+export interface CustomFieldNumber {
+  id: string
+  label: string
+  type: 'number'
+  value: number
+}
+
+export interface CustomFieldRange {
+  id: string
+  label: string
+  type: 'range'
+  value: { min: number; max: number | null }
+}
+
+export type CustomField = CustomFieldText | CustomFieldNumber | CustomFieldRange
+export type CustomFieldType = CustomField['type']
 
 export interface Equipment {
   id: string
@@ -22,6 +45,7 @@ export interface Equipment {
   requiresApproval: boolean   // triggers approval flow when booked
   approverId: string | null   // specific user who must approve; Admin if null
   createdAt: string | null    // ISO string (converted from Timestamp at read boundary)
+  customFields: CustomField[] // defaults to []
   units?: EquipmentUnit[]     // hydrated at query time, never stored in Firestore
 }
 
@@ -32,7 +56,6 @@ export interface EquipmentUnit {
   label: string         // e.g. "Kamera 1"
   serialNumber: string | null
   status: EquipmentStatus
-  condition: UnitCondition
   notes: string | null
   active: boolean
   createdAt: string | null

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -16,21 +16,14 @@ export interface CustomFieldText {
   value: string
 }
 
-export interface CustomFieldNumber {
+export interface CustomFieldValue {
   id: string
   label: string
-  type: 'number'
-  value: number
-}
-
-export interface CustomFieldRange {
-  id: string
-  label: string
-  type: 'range'
+  type: 'value'
   value: { min: number; max: number | null }
 }
 
-export type CustomField = CustomFieldText | CustomFieldNumber | CustomFieldRange
+export type CustomField = CustomFieldText | CustomFieldValue
 export type CustomFieldType = CustomField['type']
 
 export interface Equipment {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,5 @@
 export type { Booking, BookingStatus, ApprovalStatus, BookingItem } from './booking'
-export type { Equipment, EquipmentUnit, EquipmentStatus, TrackingType, UnitCondition } from './equipment'
+export type { Equipment, EquipmentUnit, EquipmentStatus, TrackingType, CustomField, CustomFieldText, CustomFieldNumber, CustomFieldRange, CustomFieldType } from './equipment'
 export { DEFAULT_EQUIPMENT_CATEGORIES } from './equipment'
 export type { Company, Subscription, SubscriptionStatus, Plan, BillingInterval } from './company'
 export type { UserProfile, Membership, TeamMember, SessionClaims, Role } from './user'

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,5 @@
 export type { Booking, BookingStatus, ApprovalStatus, BookingItem } from './booking'
-export type { Equipment, EquipmentUnit, EquipmentStatus, TrackingType, CustomField, CustomFieldText, CustomFieldNumber, CustomFieldRange, CustomFieldType } from './equipment'
+export type { Equipment, EquipmentUnit, EquipmentStatus, TrackingType, CustomField, CustomFieldText, CustomFieldValue, CustomFieldType } from './equipment'
 export { DEFAULT_EQUIPMENT_CATEGORIES } from './equipment'
 export type { Company, Subscription, SubscriptionStatus, Plan, BillingInterval } from './company'
 export type { UserProfile, Membership, TeamMember, SessionClaims, Role } from './user'


### PR DESCRIPTION
Fixes #48

- Add custom field types (text, value) to Equipment — value supports single number or range (min/max)
- Dynamic custom fields section in EquipmentForm, placed after Description
- Cloud Function validation with 20-field cap
- Remove UnitCondition / condition from EquipmentUnit and UnitForm