### PR TITLE
feat(bookings): Phase 3 — availability UX, mobile, calendar views, approval MVP

### DIFF
--- a/actions/bookings.ts
+++ b/actions/bookings.ts
@@ -899,6 +899,77 @@ export async function approveBooking(
   }
 }
 
+// ── getBookedSummary (availability pre-check for all equipment) ──────────────
+
+/**
+ * Summary of what is already booked for one equipment item in a date range.
+ * Used by BookingForm to display proactive availability before items are selected.
+ */
+export interface BookedSummary {
+  /** Total quantity already booked (for quantity-tracked equipment). */
+  quantity: number
+  /** Unit IDs already booked (for serialized equipment). */
+  unitIds: string[]
+}
+
+/**
+ * Returns a map of equipmentId → BookedSummary for all equipment that has
+ * at least one booking overlapping [startDate, endDate].
+ * Advisory only — never blocks the UI. Returns {} on any error.
+ */
+export async function getBookedSummary(
+  companyId: string,
+  startDate: string,
+  endDate: string,
+): Promise<Record<string, BookedSummary>> {
+  const session = await getVerifiedSession()
+  if (companyId !== session.activeCompanyId) return {}
+
+  let validatedStart: string
+  let validatedEnd: string
+  try {
+    validatedStart = validateDateString(startDate, 'startDate')
+    validatedEnd   = validateDateString(endDate, 'endDate')
+  } catch {
+    return {}
+  }
+  if (validatedEnd < validatedStart) return {}
+
+  try {
+    // Single query: all non-cancelled bookings whose endDate >= our startDate.
+    const snap = await adminDb
+      .collection(`companies/${session.activeCompanyId}/bookings`)
+      .where('endDate', '>=', validatedStart)
+      .get()
+
+    const summary: Record<string, BookedSummary> = {}
+
+    for (const doc of snap.docs) {
+      const data = doc.data() as StoredBookingForConflict
+      if (data.status === 'cancelled') continue
+      if (data.approvalStatus === 'rejected') continue
+      if (data.startDate > validatedEnd) continue  // no overlap
+
+      for (const item of data.items ?? []) {
+        if (!summary[item.equipmentId]) {
+          summary[item.equipmentId] = { quantity: 0, unitIds: [] }
+        }
+        summary[item.equipmentId].quantity += item.quantity ?? 0
+        if (item.unitId) {
+          summary[item.equipmentId].unitIds.push(item.unitId)
+        }
+      }
+    }
+
+    return summary
+  } catch (err) {
+    console.error('[actions/bookings] getBookedSummary failed', {
+      message: err instanceof Error ? err.message : String(err),
+    })
+    return {}
+  }
+}
+
 // ── checkConflict (read-only pre-check) ─────────────────────────────────────
 
 export async function checkConflict(

--- a/app/(app)/(bookings-views)/bookings/4weeks/page.tsx
+++ b/app/(app)/(bookings-views)/bookings/4weeks/page.tsx
@@ -1,12 +1,59 @@
-import styles from './page.module.css'
+import { getVerifiedSession } from '@/lib/dal'
+import { getBookings } from '@/lib/queries/bookings'
+import Booking4WeekView from '@/components/bookings/Booking4WeekView'
 
 /**
- * 4-week view — coming in Phase 4.
+ * 4-Week view page — Server Component shell.
+ * Passes session data and initial bookings to Booking4WeekView Client Component.
+ * Period is controlled by URL param (?start=YYYY-MM-DD — must be a Monday).
  */
-export default function BookingsFourWeeksPage() {
+export default async function Bookings4WeeksPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ start?: string }>
+}) {
+  const session = await getVerifiedSession()
+  const sp      = await searchParams
+
+  // Default to the Monday of the current week
+  const periodStart = sp.start ?? getMondayString(new Date())
+
+  // Fetch bookings for the 28-day window
+  const endDate = offsetDate(periodStart, 27)
+
+  const initialBookings = await getBookings(session.activeCompanyId, {
+    startDate: periodStart,
+    endDate,
+  })
+
   return (
-    <div className={styles.stub}>
-      <span className={styles.label}>4-week view — coming soon</span>
-    </div>
+    <Booking4WeekView
+      companyId={session.activeCompanyId}
+      initialBookings={initialBookings}
+      periodStart={periodStart}
+    />
   )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/** Returns the Monday of the ISO week containing the given date. */
+function getMondayString(date: Date): string {
+  const d   = new Date(date)
+  const day = (d.getDay() + 6) % 7  // Mon=0 … Sun=6
+  d.setDate(d.getDate() - day)
+  return toDateString(d)
+}
+
+/** Returns the date string N days after the given date string. */
+function offsetDate(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  d.setDate(d.getDate() + days)
+  return toDateString(d)
 }

--- a/app/(app)/(bookings-views)/bookings/month/page.tsx
+++ b/app/(app)/(bookings-views)/bookings/month/page.tsx
@@ -1,12 +1,43 @@
-import styles from './page.module.css'
+import { getVerifiedSession } from '@/lib/dal'
+import { getBookings } from '@/lib/queries/bookings'
+import BookingMonthView from '@/components/bookings/BookingMonthView'
 
 /**
- * Month view — coming in Phase 4.
+ * Month view page — Server Component shell.
+ * Passes session data and initial bookings to BookingMonthView Client Component.
+ * Month is controlled by URL params (?year=2026&month=4).
  */
-export default function BookingsMonthPage() {
+export default async function BookingsMonthPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ year?: string; month?: string }>
+}) {
+  const session = await getVerifiedSession()
+  const sp      = await searchParams
+
+  const now        = new Date()
+  const year       = sp.year  ? parseInt(sp.year,  10) : now.getFullYear()
+  const month      = sp.month ? parseInt(sp.month, 10) : now.getMonth() + 1
+
+  // Fetch bookings for the full month
+  const firstDay = new Date(year, month - 1, 1)
+  const lastDay  = new Date(year, month, 0)
+
+  function toDateString(d: Date): string {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+
+  const initialBookings = await getBookings(session.activeCompanyId, {
+    startDate: toDateString(firstDay),
+    endDate:   toDateString(lastDay),
+  })
+
   return (
-    <div className={styles.stub}>
-      <span className={styles.label}>Month view — coming soon</span>
-    </div>
+    <BookingMonthView
+      companyId={session.activeCompanyId}
+      initialBookings={initialBookings}
+      year={year}
+      month={month}
+    />
   )
 }

--- a/components/bookings/Booking4WeekView.module.css
+++ b/components/bookings/Booking4WeekView.module.css
@@ -1,0 +1,175 @@
+/* -----------------------------------------------------------------------
+   Booking 4-Week View — compact 4-row × 7-column grid
+   ----------------------------------------------------------------------- */
+
+.container {
+  width: 100%;
+}
+
+/* Nav bar */
+.navBar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px var(--booking-pad-h);
+  border-bottom: 1px solid var(--rule);
+}
+
+.navBtn {
+  background: none;
+  border: 1px solid var(--dim);
+  color: var(--mid);
+  font-size: 16px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.navBtn:hover {
+  color: var(--white);
+  border-color: var(--white);
+}
+
+.periodLabel {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--white);
+  min-width: 260px;
+}
+
+.todayBtn {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mid);
+  background: none;
+  border: 1px solid var(--dim);
+  padding: 4px 12px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.todayBtn:hover {
+  color: var(--white);
+  border-color: var(--white);
+}
+
+/* 7-column grid */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  border-left: 1px solid var(--rule);
+  border-top: 1px solid var(--rule);
+}
+
+/* Weekday header */
+.dayHeader {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mid);
+  padding: 6px 10px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+/* Day cell — compact */
+.day {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 6px 8px;
+  min-height: 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dayToday {
+  background: rgba(238, 204, 2, 0.04);
+}
+
+.dayMeta {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.dayWeekday {
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--dim);
+}
+
+.dayDate {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--mid);
+}
+
+.dayDateToday {
+  color: var(--accent);
+}
+
+/* Bookings inside a day cell */
+.dayBookings {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Booking pill */
+.block {
+  display: block;
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: opacity 0.1s;
+}
+
+.block:hover {
+  opacity: 0.8;
+}
+
+/* Status-specific pill colours */
+.blockCheckedOut {
+  background: rgba(238, 204, 2, 0.15);
+  color: var(--accent);
+}
+
+.blockConfirmed {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+}
+
+.blockPending {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--mid);
+}
+
+.blockReturned {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--dim);
+}
+
+.moreBookings {
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--mid);
+}

--- a/components/bookings/Booking4WeekView.tsx
+++ b/components/bookings/Booking4WeekView.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useBookings } from '@/hooks/useBookings'
+import type { Booking } from '@/types'
+import styles from './Booking4WeekView.module.css'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function todayString(): string {
+  return toDateString(new Date())
+}
+
+/** Returns the Monday of the ISO week containing the given date. */
+function getMondayOf(dateStr: string): Date {
+  const d = new Date(dateStr + 'T00:00:00')
+  const day = (d.getDay() + 6) % 7  // Mon=0 … Sun=6
+  d.setDate(d.getDate() - day)
+  return d
+}
+
+/** Returns 28 consecutive date strings starting from a Monday. */
+function get28Days(startMonday: string): string[] {
+  const days: string[] = []
+  const start = new Date(startMonday + 'T00:00:00')
+  for (let i = 0; i < 28; i++) {
+    const d = new Date(start)
+    d.setDate(start.getDate() + i)
+    days.push(toDateString(d))
+  }
+  return days
+}
+
+function formatDayHeader(dateStr: string): { weekday: string; date: string } {
+  const d = new Date(dateStr + 'T00:00:00')
+  return {
+    weekday: d.toLocaleDateString('en-GB', { weekday: 'short' }).toUpperCase(),
+    date:    d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' }),
+  }
+}
+
+function formatPeriodLabel(startStr: string, endStr: string): string {
+  const s = new Date(startStr + 'T00:00:00')
+  const e = new Date(endStr   + 'T00:00:00')
+  const startLabel = s.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+  const endLabel   = e.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return `${startLabel} — ${endLabel}`.toUpperCase()
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case 'checked_out': return styles.blockCheckedOut
+    case 'confirmed':   return styles.blockConfirmed
+    case 'pending':     return styles.blockPending
+    case 'returned':    return styles.blockReturned
+    default:            return styles.blockPending
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface Booking4WeekViewProps {
+  companyId: string
+  initialBookings: Booking[]
+  /** Monday that starts the 4-week period — "YYYY-MM-DD" */
+  periodStart: string
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function Booking4WeekView({
+  companyId,
+  initialBookings,
+  periodStart,
+}: Booking4WeekViewProps) {
+  const router = useRouter()
+
+  const days    = useMemo(() => get28Days(periodStart), [periodStart])
+  const endDate = days[27]
+  const today   = todayString()
+
+  const { bookings: liveBookings, loading } = useBookings(companyId, {
+    startDate: periodStart,
+    endDate:   endDate,
+  })
+
+  const bookings = loading ? initialBookings : liveBookings
+
+  function bookingsForDay(dayStr: string): Booking[] {
+    return bookings.filter(
+      (b) => b.startDate <= dayStr && b.endDate >= dayStr && b.status !== 'cancelled',
+    )
+  }
+
+  // Navigation: shift by 28 days
+  function prevPeriod(): string {
+    const d = new Date(periodStart + 'T00:00:00')
+    d.setDate(d.getDate() - 28)
+    return toDateString(d)
+  }
+
+  function nextPeriod(): string {
+    const d = new Date(periodStart + 'T00:00:00')
+    d.setDate(d.getDate() + 28)
+    return toDateString(d)
+  }
+
+  function navigate(start: string) {
+    router.push(`/bookings/4weeks?start=${start}`)
+  }
+
+  function goToToday() {
+    const monday = getMondayOf(todayString())
+    navigate(toDateString(monday))
+  }
+
+  // Split 28 days into 4 rows of 7
+  const weeks: string[][] = []
+  for (let i = 0; i < 4; i++) {
+    weeks.push(days.slice(i * 7, i * 7 + 7))
+  }
+
+  const WEEKDAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+
+  return (
+    <div className={styles.container}>
+      {/* Nav bar */}
+      <div className={styles.navBar}>
+        <button className={styles.navBtn} onClick={() => navigate(prevPeriod())}>←</button>
+        <span className={styles.periodLabel}>{formatPeriodLabel(periodStart, endDate)}</span>
+        <button className={styles.navBtn} onClick={() => navigate(nextPeriod())}>→</button>
+        <button className={styles.todayBtn} onClick={goToToday}>Today</button>
+      </div>
+
+      {/* Grid: header row + 4 week rows */}
+      <div className={styles.grid}>
+        {/* Weekday headers */}
+        {WEEKDAYS.map((wd) => (
+          <div key={wd} className={styles.dayHeader}>{wd}</div>
+        ))}
+
+        {/* Day cells — 4 rows */}
+        {days.map((dayStr) => {
+          const isToday     = dayStr === today
+          const dayBookings = bookingsForDay(dayStr)
+          const h           = formatDayHeader(dayStr)
+
+          return (
+            <div
+              key={dayStr}
+              className={`${styles.day} ${isToday ? styles.dayToday : ''}`}
+            >
+              <div className={styles.dayMeta}>
+                <span className={styles.dayWeekday}>{h.weekday}</span>
+                <span className={`${styles.dayDate} ${isToday ? styles.dayDateToday : ''}`}>
+                  {h.date}
+                </span>
+              </div>
+              <div className={styles.dayBookings}>
+                {dayBookings.slice(0, 2).map((booking) => (
+                  <Link
+                    key={booking.id}
+                    href={`/bookings/${booking.id}`}
+                    className={`${styles.block} ${statusClass(booking.status)}`}
+                  >
+                    {booking.projectName}
+                  </Link>
+                ))}
+                {dayBookings.length > 2 && (
+                  <span className={styles.moreBookings}>+{dayBookings.length - 2}</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/bookings/BookingDetail.module.css
+++ b/components/bookings/BookingDetail.module.css
@@ -85,12 +85,18 @@
   margin-bottom: 24px;
 }
 
-/* Body: 2-column layout */
+/* Body: stacked on mobile, 2-column on desktop */
 .body {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 24px;
   min-height: calc(100vh - 300px);
+}
+
+@media (min-width: 768px) {
+  .body {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 /* Details column */

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -232,7 +232,7 @@ export default function BookingDetail({
 
         {/* Actions panel */}
         <div className={styles.actions}>
-          {/* Approve / Reject */}
+          {/* Approve / Reject — hidden for MVP, re-enable in Phase 5
           {canApprove && (
             <div className={styles.approvalSection}>
               <div className={styles.approvalLabel}>Approval Required</div>
@@ -276,7 +276,7 @@ export default function BookingDetail({
                 </div>
               )}
             </div>
-          )}
+          )} */}
 
           {/* Cancel booking */}
           {canCancel && (

--- a/components/bookings/BookingForm.module.css
+++ b/components/bookings/BookingForm.module.css
@@ -280,6 +280,23 @@
   padding: 2px 6px;
 }
 
+/* Proactive availability tags — shown before item selection */
+.availabilityCount {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.availabilityNone {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--repair);
+}
+
 /* Unit dropdown (serialized items) */
 .unitDropdownRow {
   display: flex;

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useMemo, useTransition } from 'react'
+import { useState, useMemo, useTransition, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { createBooking, checkConflict } from '@/actions/bookings'
+import { createBooking, checkConflict, getBookedSummary } from '@/actions/bookings'
 import { useToast } from '@/lib/toast-context'
 import type { Equipment } from '@/types'
-import type { ConflictResult } from '@/actions/bookings'
+import type { ConflictResult, BookedSummary } from '@/actions/bookings'
 import styles from './BookingForm.module.css'
 
 interface BookingFormProps {
@@ -49,7 +49,19 @@ export default function BookingForm({
   const [error, setError]               = useState<string | null>(null)
   const [conflictResult, setConflictResult] = useState<ConflictResult | null>(null)
   const [isCheckingConflict, setIsCheckingConflict] = useState(false)
+  const [bookedSummary, setBookedSummary] = useState<Record<string, BookedSummary> | null>(null)
+  const [isLoadingAvailability, setIsLoadingAvailability] = useState(false)
   const [isPending, startTransition]    = useTransition()
+
+  // Load availability on mount (default dates are already set)
+  useEffect(() => {
+    if (!defaultStartDate || !defaultEndDate) return
+    setIsLoadingAvailability(true)
+    getBookedSummary(companyId, defaultStartDate, defaultEndDate)
+      .then(setBookedSummary)
+      .finally(() => setIsLoadingAvailability(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const bookableEquipment = equipment.filter((e) => e.availableForBooking !== false)
   const grouped = useMemo(() => groupByCategory(bookableEquipment), [bookableEquipment])
@@ -92,14 +104,22 @@ export default function BookingForm({
     setConflictResult(null)
   }
 
+  function sortedSerializedUnits(eq: Equipment): typeof eq.units {
+    const bookable = (eq.units ?? []).filter(u => u.availableForBooking !== false)
+    const booked = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
+    const available   = bookable.filter(u => !booked.has(u.id)).sort((a, b) => a.label.localeCompare(b.label))
+    const unavailable = bookable.filter(u =>  booked.has(u.id)).sort((a, b) => a.label.localeCompare(b.label))
+    return [...available, ...unavailable]
+  }
+
   function toggleSerializedItem(eq: Equipment) {
-    const units = (eq.units ?? []).filter(u => u.availableForBooking !== false)
+    const sorted = sortedSerializedUnits(eq)
     setSelectedItems((prev) => {
       const hasSelection = prev.some((i) => i.equipmentId === eq.id && i.unitId)
       if (hasSelection) {
         return prev.filter((i) => i.equipmentId !== eq.id || !i.unitId)
       }
-      const firstUnit = units[0]
+      const firstUnit = sorted[0]
       if (!firstUnit) return prev
       const without = prev.filter((i) => i.equipmentId !== eq.id || !i.unitId)
       return [...without, { equipmentId: eq.id, unitId: firstUnit.id, quantity: 1 }]
@@ -132,17 +152,25 @@ export default function BookingForm({
       setEndDate(value)
     }
 
-    if (selectedItems.length === 0) return
     if (!newStart || !newEnd) return
 
     const effectiveEnd = newEnd < newStart ? newStart : newEnd
 
-    setIsCheckingConflict(true)
-    try {
-      const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems)
-      setConflictResult(result)
-    } finally {
-      setIsCheckingConflict(false)
+    // Always refresh availability for all equipment when dates change
+    setIsLoadingAvailability(true)
+    getBookedSummary(companyId, newStart, effectiveEnd)
+      .then(setBookedSummary)
+      .finally(() => setIsLoadingAvailability(false))
+
+    // Also re-check conflicts for already-selected items
+    if (selectedItems.length > 0) {
+      setIsCheckingConflict(true)
+      try {
+        const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems)
+        setConflictResult(result)
+      } finally {
+        setIsCheckingConflict(false)
+      }
     }
   }
 
@@ -309,7 +337,7 @@ export default function BookingForm({
           {/* Equipment */}
           <div className={styles.field}>
             <div className={styles.sectionLabel}>Equipment</div>
-            {isCheckingConflict && (
+            {(isCheckingConflict || isLoadingAvailability) && (
               <div className={styles.conflictChecking}>Checking availability…</div>
             )}
             {bookableEquipment.length === 0 ? (
@@ -327,9 +355,14 @@ export default function BookingForm({
                       const hasConflict = conflictIds.has(eq.id)
 
                       if (eq.trackingType === 'serialized') {
-                        const units = (eq.units ?? []).filter(u => u.availableForBooking !== false)
+                        const units = sortedSerializedUnits(eq)
                         const selectedUnitId = getSelectedUnitId(eq.id)
                         const isChecked = !!selectedUnitId
+
+                        // Proactive availability from bookedSummary
+                        const bookedUnitIds = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
+                        const availableUnits = units.filter(u => !bookedUnitIds.has(u.id))
+                        const proactiveUnavailable = bookedSummary !== null && availableUnits.length === 0
 
                         return (
                           <div key={eq.id} className={`${styles.equipmentBox} ${hasConflict ? styles.equipmentBoxConflict : ''}`}>
@@ -346,6 +379,13 @@ export default function BookingForm({
                               <div className={styles.equipmentMeta}>
                                 <span className={styles.equipmentName}>{eq.name}</span>
                                 <span className={styles.typeTag}>UNITS</span>
+                                {bookedSummary !== null && !hasConflict && (
+                                  proactiveUnavailable
+                                    ? <span className={styles.availabilityNone}>Unavailable</span>
+                                    : availableUnits.length < units.length
+                                      ? <span className={styles.availabilityCount}>{availableUnits.length} of {units.length} free</span>
+                                      : null
+                                )}
                               </div>
                               {eq.requiresApproval && (
                                 <span className={styles.approvalTag}>Approval required</span>
@@ -362,11 +402,14 @@ export default function BookingForm({
                                   value={selectedUnitId ?? ''}
                                   onChange={(e) => selectUnit(eq.id, e.target.value)}
                                 >
-                                  {units.map((unit) => (
-                                    <option key={unit.id} value={unit.id}>
-                                      {unit.label}{unit.serialNumber ? ` — S/N ${unit.serialNumber}` : ''}
-                                    </option>
-                                  ))}
+                                  {units.map((unit) => {
+                                    const isUnitBooked = bookedUnitIds.has(unit.id)
+                                    return (
+                                      <option key={unit.id} value={unit.id}>
+                                        {unit.label}{unit.serialNumber ? ` — S/N ${unit.serialNumber}` : ''}{isUnitBooked ? ' (Unavailable)' : ''}
+                                      </option>
+                                    )
+                                  })}
                                 </select>
                               </div>
                             )}
@@ -382,6 +425,12 @@ export default function BookingForm({
                       // quantity equipment
                       const selected = isSelected(eq.id)
                       const qty = selected ? getQuantity(eq.id) : 0
+
+                      // Proactive availability from bookedSummary
+                      const qtyBooked = bookedSummary?.[eq.id]?.quantity ?? 0
+                      const qtyAvailable = eq.totalQuantity - qtyBooked
+                      const proactiveUnavailable = bookedSummary !== null && qtyAvailable <= 0
+
                       return (
                         <div key={eq.id} className={`${styles.equipmentBox} ${hasConflict ? styles.equipmentBoxConflict : ''}`}>
                           <div className={`${styles.equipmentRow} ${selected ? styles.equipmentRowSelected : ''}`}>
@@ -398,6 +447,13 @@ export default function BookingForm({
                               <div className={styles.equipmentMeta}>
                                 <span className={styles.equipmentName}>{eq.name}</span>
                                 <span className={styles.typeTag}>QTY</span>
+                                {bookedSummary !== null && !hasConflict && (
+                                  proactiveUnavailable
+                                    ? <span className={styles.availabilityNone}>Unavailable</span>
+                                    : qtyBooked > 0
+                                      ? <span className={styles.availabilityCount}>{qtyAvailable} of {eq.totalQuantity} available</span>
+                                      : null
+                                )}
                                 {eq.requiresApproval && (
                                   <span className={styles.approvalTag}>Approval required</span>
                                 )}

--- a/components/bookings/BookingMonthView.module.css
+++ b/components/bookings/BookingMonthView.module.css
@@ -1,0 +1,198 @@
+/* -----------------------------------------------------------------------
+   Booking Month View — calendar grid
+   ----------------------------------------------------------------------- */
+
+.container {
+  width: 100%;
+}
+
+/* Nav bar */
+.navBar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px var(--booking-pad-h);
+  border-bottom: 1px solid var(--rule);
+}
+
+.navBtn {
+  background: none;
+  border: 1px solid var(--dim);
+  color: var(--mid);
+  font-size: 16px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.navBtn:hover {
+  color: var(--white);
+  border-color: var(--white);
+}
+
+.monthLabel {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--white);
+  min-width: 200px;
+}
+
+.todayBtn {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mid);
+  background: none;
+  border: 1px solid var(--dim);
+  padding: 4px 12px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.todayBtn:hover {
+  color: var(--white);
+  border-color: var(--white);
+}
+
+/* 7-column calendar grid */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  border-left: 1px solid var(--rule);
+  border-top: 1px solid var(--rule);
+}
+
+/* Weekday header row */
+.dayHeader {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--mid);
+  padding: 8px 12px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+/* Empty padding cell (before/after month) */
+.dayEmpty {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: rgba(255, 255, 255, 0.01);
+  min-height: 100px;
+}
+
+/* Day cell */
+.day {
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  padding: 8px;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dayToday {
+  background: rgba(238, 204, 2, 0.04);
+}
+
+.dayNum {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--mid);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.dayNumToday {
+  color: var(--accent);
+}
+
+/* Bookings inside a day cell */
+.dayBookings {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+/* Booking pill */
+.block {
+  display: block;
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: opacity 0.1s;
+}
+
+.block:hover {
+  opacity: 0.8;
+}
+
+/* Status-specific pill colours */
+.blockCheckedOut {
+  background: rgba(238, 204, 2, 0.15);
+  color: var(--accent);
+}
+
+.blockConfirmed {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+}
+
+.blockPending {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--mid);
+}
+
+.blockReturned {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--dim);
+}
+
+.moreBookings {
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--mid);
+  padding: 1px 4px;
+}
+
+/* Empty state */
+.emptyState {
+  padding: 60px var(--booking-pad-h);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--mid);
+  font-size: 14px;
+}
+
+.emptyAction {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--white);
+  border: 1px solid var(--white);
+  padding: 8px 20px;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.emptyAction:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}

--- a/components/bookings/BookingMonthView.tsx
+++ b/components/bookings/BookingMonthView.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { useBookings } from '@/hooks/useBookings'
+import BookingStatusBadge from './BookingStatusBadge'
+import type { Booking } from '@/types'
+import styles from './BookingMonthView.module.css'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toDateString(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function todayString(): string {
+  return toDateString(new Date())
+}
+
+function getMonthBounds(year: number, month: number): { start: string; end: string } {
+  const start = new Date(year, month - 1, 1)
+  const end   = new Date(year, month, 0)
+  return { start: toDateString(start), end: toDateString(end) }
+}
+
+/** Returns an array of 35 or 42 slots (some null = padding days outside month). */
+function getMonthGrid(year: number, month: number): (string | null)[] {
+  const firstDay     = new Date(year, month - 1, 1)
+  const lastDay      = new Date(year, month, 0)
+  const startPadding = (firstDay.getDay() + 6) % 7  // Mon=0 … Sun=6
+
+  const days: (string | null)[] = []
+  for (let i = 0; i < startPadding; i++) days.push(null)
+  for (let d = 1; d <= lastDay.getDate(); d++) {
+    days.push(toDateString(new Date(year, month - 1, d)))
+  }
+  while (days.length % 7 !== 0) days.push(null)
+  return days
+}
+
+function formatMonthYear(year: number, month: number): string {
+  const d = new Date(year, month - 1, 1)
+  return d.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }).toUpperCase()
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case 'checked_out': return styles.blockCheckedOut
+    case 'confirmed':   return styles.blockConfirmed
+    case 'pending':     return styles.blockPending
+    case 'returned':    return styles.blockReturned
+    default:            return styles.blockPending
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface BookingMonthViewProps {
+  companyId: string
+  initialBookings: Booking[]
+  year: number
+  month: number
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function BookingMonthView({
+  companyId,
+  initialBookings,
+  year,
+  month,
+}: BookingMonthViewProps) {
+  const router = useRouter()
+  const { start, end } = getMonthBounds(year, month)
+
+  const { bookings: liveBookings, loading } = useBookings(companyId, {
+    startDate: start,
+    endDate:   end,
+  })
+
+  const bookings = loading ? initialBookings : liveBookings
+  const today    = todayString()
+  const grid     = useMemo(() => getMonthGrid(year, month), [year, month])
+
+  function bookingsForDay(dayStr: string): Booking[] {
+    return bookings.filter(
+      (b) => b.startDate <= dayStr && b.endDate >= dayStr && b.status !== 'cancelled',
+    )
+  }
+
+  // Navigation
+  const prevYear  = month === 1 ? year - 1 : year
+  const prevMonth = month === 1 ? 12 : month - 1
+  const nextYear  = month === 12 ? year + 1 : year
+  const nextMonth = month === 12 ? 1 : month + 1
+
+  function navigate(y: number, m: number) {
+    router.push(`/bookings/month?year=${y}&month=${m}`)
+  }
+
+  const WEEKDAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+
+  return (
+    <div className={styles.container}>
+      {/* Nav bar */}
+      <div className={styles.navBar}>
+        <button
+          className={styles.navBtn}
+          onClick={() => navigate(prevYear, prevMonth)}
+        >
+          ←
+        </button>
+        <span className={styles.monthLabel}>{formatMonthYear(year, month)}</span>
+        <button
+          className={styles.navBtn}
+          onClick={() => navigate(nextYear, nextMonth)}
+        >
+          →
+        </button>
+        <button
+          className={styles.todayBtn}
+          onClick={() => {
+            const now = new Date()
+            navigate(now.getFullYear(), now.getMonth() + 1)
+          }}
+        >
+          Today
+        </button>
+      </div>
+
+      {/* Weekday header row */}
+      <div className={styles.grid}>
+        {WEEKDAYS.map((wd) => (
+          <div key={wd} className={styles.dayHeader}>{wd}</div>
+        ))}
+
+        {/* Day cells */}
+        {grid.map((dayStr, i) => {
+          if (!dayStr) {
+            return <div key={`pad-${i}`} className={styles.dayEmpty} />
+          }
+
+          const isToday     = dayStr === today
+          const dayBookings = bookingsForDay(dayStr)
+          const dayNum      = new Date(dayStr + 'T00:00:00').getDate()
+
+          return (
+            <div
+              key={dayStr}
+              className={`${styles.day} ${isToday ? styles.dayToday : ''}`}
+            >
+              <span className={`${styles.dayNum} ${isToday ? styles.dayNumToday : ''}`}>
+                {dayNum}
+              </span>
+              <div className={styles.dayBookings}>
+                {dayBookings.slice(0, 3).map((booking) => (
+                  <Link
+                    key={booking.id}
+                    href={`/bookings/${booking.id}`}
+                    className={`${styles.block} ${statusClass(booking.status)}`}
+                  >
+                    {booking.projectName}
+                  </Link>
+                ))}
+                {dayBookings.length > 3 && (
+                  <span className={styles.moreBookings}>+{dayBookings.length - 3} more</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Empty state */}
+      {bookings.filter((b) => b.status !== 'cancelled').length === 0 && (
+        <div className={styles.emptyState}>
+          <p>No bookings this month.</p>
+          <Link href="/bookings/new" className={styles.emptyAction}>
+            New Booking
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/bookings/BookingWeekView.module.css
+++ b/components/bookings/BookingWeekView.module.css
@@ -60,11 +60,77 @@
   border-color: var(--white);
 }
 
-/* 7-column grid */
+/* Mobile: single-day view — visible only on small screens */
+.mobileView {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 768px) {
+  .mobileView {
+    display: none;
+  }
+}
+
+.mobileDayNav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px var(--booking-pad-h);
+  border-bottom: 1px solid var(--rule);
+}
+
+.mobileDayTitle {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: center;
+}
+
+.mobileDayWeekday {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--mid);
+}
+
+.mobileDayDate {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--mid);
+}
+
+.mobileDayDateToday {
+  color: var(--accent);
+}
+
+.mobileDayBody {
+  padding: 16px var(--booking-pad-h);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 200px;
+}
+
+.mobileDayEmpty {
+  font-size: 12px;
+  color: var(--mid);
+  padding: 24px 0;
+}
+
+/* 7-column grid — hidden on mobile, shown on desktop */
 .grid {
-  display: grid;
+  display: none;
   grid-template-columns: repeat(7, 1fr);
   border-left: 1px solid var(--rule);
+}
+
+@media (min-width: 768px) {
+  .grid {
+    display: grid;
+  }
 }
 
 /* Day column */

--- a/components/bookings/BookingWeekView.tsx
+++ b/components/bookings/BookingWeekView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { useBookings } from '@/hooks/useBookings'
@@ -105,6 +105,23 @@ export default function BookingWeekView({
   const days     = useMemo(() => getDaysOfWeek(weekStart), [weekStart])
   const today    = todayString()
 
+  // Mobile: single-day navigation
+  const [selectedDay, setSelectedDay] = useState(
+    days.includes(today) ? today : days[0],
+  )
+
+  function prevDay() {
+    const d = new Date(selectedDay + 'T00:00:00')
+    d.setDate(d.getDate() - 1)
+    setSelectedDay(toDateString(d))
+  }
+
+  function nextDay() {
+    const d = new Date(selectedDay + 'T00:00:00')
+    d.setDate(d.getDate() + 1)
+    setSelectedDay(toDateString(d))
+  }
+
   // Group bookings by which days they span
   function bookingsForDay(dayStr: string): Booking[] {
     return bookings.filter(
@@ -151,7 +168,38 @@ export default function BookingWeekView({
         </button>
       </div>
 
-      {/* Grid */}
+      {/* Mobile: single-day view */}
+      <div className={styles.mobileView}>
+        <div className={styles.mobileDayNav}>
+          <button className={styles.navBtn} onClick={prevDay}>←</button>
+          <div className={styles.mobileDayTitle}>
+            {(() => {
+              const h = formatDayHeader(selectedDay)
+              const isSelectedToday = selectedDay === today
+              return (
+                <>
+                  <span className={styles.mobileDayWeekday}>{h.weekday}</span>
+                  <span className={`${styles.mobileDayDate} ${isSelectedToday ? styles.mobileDayDateToday : ''}`}>
+                    {h.date}
+                  </span>
+                </>
+              )
+            })()}
+          </div>
+          <button className={styles.navBtn} onClick={nextDay}>→</button>
+        </div>
+        <div className={styles.mobileDayBody}>
+          {bookingsForDay(selectedDay).length === 0 ? (
+            <div className={styles.mobileDayEmpty}>No bookings</div>
+          ) : (
+            bookingsForDay(selectedDay).map((booking) => (
+              <BookingBlock key={booking.id} booking={booking} />
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Desktop: 7-column week grid */}
       <div className={styles.grid}>
         {days.map((day) => {
           const isToday   = day === today

--- a/components/nav/BookingsSecondaryNav.tsx
+++ b/components/nav/BookingsSecondaryNav.tsx
@@ -13,8 +13,8 @@ interface NavItem {
 const ITEMS: NavItem[] = [
   { label: 'List',    href: '/bookings' },
   { label: 'Week',    href: '/bookings/week' },
-  { label: 'Month',   href: '/bookings/month',   disabled: true },
-  { label: '4 Weeks', href: '/bookings/4weeks',  disabled: true },
+  { label: 'Month',   href: '/bookings/month' },
+  { label: '4 Weeks', href: '/bookings/4weeks' },
 ]
 
 /**


### PR DESCRIPTION
## Summary

- **#53** — Proactive availability in booking form: equipment cards now show "X of Y available" or "Unavailable" as soon as dates are picked — before any item is selected. Unit dropdown sorts available units first (A–Z), unavailable last with "(Unavailable)" label.
- **#66** — Mobile responsiveness: BookingDetail collapses to single-column on mobile; BookingWeekView adds a single-day view with ← → navigation on mobile (<768px).
- **#67** — Calendar views: full BookingMonthView (month grid) and Booking4WeekView (28-day compact grid) built and wired up. Month and 4 Weeks tabs enabled in secondary nav.
- **#68** — Approval flow hidden for MVP: Approve/Reject UI commented out in BookingDetail; data structures and Cloud Functions intact.

Closes #53
Closes #66
Closes #67
Closes #68

## Test plan

- [ ] Open `/bookings/new`, pick dates overlapping existing bookings → availability tags appear on equipment cards before selection
- [ ] Unit dropdown shows available units first, unavailable marked with "(Unavailable)"
- [ ] Open a booking detail on mobile → single-column layout
- [ ] Week view on mobile → single-day view with day navigation arrows
- [ ] `/bookings/month` — calendar grid renders, prev/next month nav works
- [ ] `/bookings/4weeks` — 28-day grid renders, prev/next 4-week nav works
- [ ] Open any booking detail → no Approve/Reject buttons visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)