### PR TITLE
feat: email verification on signup (#70)

### DIFF
--- a/__tests__/auth/session.test.ts
+++ b/__tests__/auth/session.test.ts
@@ -122,17 +122,85 @@ describe('getVerifiedSession', () => {
       email:           'user@example.com',
       activeCompanyId: 'company-abc',
       role:            'admin',
+      email_verified:  true,
     })
 
-    // React.cache memoises the first resolved value per module lifetime.
-    // Earlier tests all threw (rejected), so no resolved value is cached yet.
-    // This call populates the cache and returns the claims.
+    // React.cache is a pass-through in tests (see __mocks__/next-cache.ts),
+    // so every call hits the mock directly with no memoisation.
     const claims = await getVerifiedSession()
 
     expect(claims.uid).toBe('user-1')
     expect(claims.email).toBe('user@example.com')
     expect(claims.activeCompanyId).toBe('company-abc')
     expect(claims.role).toBe('admin')
+  })
+
+  // ── email_verified checks (issue #70) ─────────────────────────────────────
+
+  it('redirects to /verify-email when email_verified is false', async () => {
+    mockCookieGet.mockReturnValue({ value: 'unverified-session-token' })
+    mockVerifySessionCookie.mockResolvedValue({
+      uid:             'user-2',
+      email:           'unverified@example.com',
+      activeCompanyId: 'company-abc',
+      role:            'admin',
+      email_verified:  false,
+    })
+
+    await expect(getVerifiedSession()).rejects.toThrow('REDIRECT:/verify-email')
+  })
+
+  it('does NOT redirect to /login when email_verified is false (route is /verify-email)', async () => {
+    mockCookieGet.mockReturnValue({ value: 'unverified-session-token' })
+    mockVerifySessionCookie.mockResolvedValue({
+      uid:             'user-2',
+      email:           'unverified@example.com',
+      activeCompanyId: 'company-abc',
+      role:            'admin',
+      email_verified:  false,
+    })
+
+    // The redirect must go to /verify-email, not /login — they are distinct
+    // routes with different UI. Asserting the wrong target would silently pass.
+    await expect(getVerifiedSession()).rejects.toThrow('REDIRECT:/verify-email')
+    await expect(getVerifiedSession()).rejects.not.toThrow('REDIRECT:/login')
+  })
+
+  it('returns SessionClaims when email_verified is true', async () => {
+    mockCookieGet.mockReturnValue({ value: 'verified-session-token' })
+    mockVerifySessionCookie.mockResolvedValue({
+      uid:             'user-3',
+      email:           'verified@example.com',
+      activeCompanyId: 'company-xyz',
+      role:            'crew',
+      email_verified:  true,
+    })
+
+    const claims = await getVerifiedSession()
+
+    expect(claims.uid).toBe('user-3')
+    expect(claims.email).toBe('verified@example.com')
+    expect(claims.activeCompanyId).toBe('company-xyz')
+    expect(claims.role).toBe('crew')
+  })
+
+  it('does not redirect to /verify-email when email_verified is undefined (legacy sessions)', async () => {
+    // Defensive: existing sessions minted before issue #70 may not carry the
+    // email_verified claim. They must continue to work — only an explicit
+    // false should gate access.
+    mockCookieGet.mockReturnValue({ value: 'legacy-session-token' })
+    mockVerifySessionCookie.mockResolvedValue({
+      uid:             'user-4',
+      email:           'legacy@example.com',
+      activeCompanyId: 'company-legacy',
+      role:            'admin',
+      // email_verified intentionally absent
+    })
+
+    const claims = await getVerifiedSession()
+
+    expect(claims.uid).toBe('user-4')
+    expect(claims.activeCompanyId).toBe('company-legacy')
   })
 })
 

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next'
+import VerifyEmailForm from '@/components/auth/VerifyEmailForm'
+
+export const metadata: Metadata = {
+  title: 'Verify Email — Allocate',
+}
+
+export default function VerifyEmailPage() {
+  return <VerifyEmailForm />
+}

--- a/components/auth/Auth.module.css
+++ b/components/auth/Auth.module.css
@@ -88,6 +88,13 @@
   padding: 10px 14px;
 }
 
+.status {
+  font-size: var(--font-body);
+  color: var(--on-surface-variant);
+  border: 1px solid var(--outline);
+  padding: 10px 14px;
+}
+
 .submitBtn {
   font-family: inherit;
   font-size: 0.75rem;

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { signInWithEmailAndPassword } from 'firebase/auth'
+import { signInWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { createSession } from '@/actions/auth'
 import styles from './Auth.module.css'
@@ -23,9 +23,16 @@ export default function LoginForm() {
 
     try {
       const credential = await signInWithEmailAndPassword(auth, email.trim(), password)
-      const idToken = await credential.user.getIdToken()
-      await createSession(idToken)
-      router.push('/bookings')
+      await credential.user.reload()
+      const idToken = await credential.user.getIdToken(true)
+      if (!credential.user.emailVerified) {
+        sendEmailVerification(credential.user).catch(() => {})
+        await createSession(idToken)
+        router.push('/verify-email')
+      } else {
+        await createSession(idToken)
+        router.push('/bookings')
+      }
     } catch (err) {
       // auth/wrong-password and auth/user-not-found are legacy SDK v8 codes;
       // SDK v9+ unifies them into auth/invalid-credential to prevent enumeration.

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { createUserWithEmailAndPassword } from 'firebase/auth'
+import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { setupNewCompany, createSession } from '@/actions/auth'
 import styles from './Auth.module.css'
@@ -57,6 +57,10 @@ export default function SignupForm() {
       return
     }
 
+    try {
+      await sendEmailVerification(credential.user)
+    } catch {/* best-effort */}
+
     // ── Step 2: Create company server-side (no CORS) ──────────────────────
     // Pass the initial token only for identity verification. Claims are set
     // inside setupNewCompany; we must refresh the token AFTER this call.
@@ -88,7 +92,7 @@ export default function SignupForm() {
       return
     }
 
-    router.push('/bookings')
+    router.push('/verify-email')
   }
 
   return (

--- a/components/auth/VerifyEmailForm.tsx
+++ b/components/auth/VerifyEmailForm.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { onAuthStateChanged, sendEmailVerification, type User } from 'firebase/auth'
+import { auth } from '@/lib/firebase'
+import { createSession } from '@/actions/auth'
+import styles from './Auth.module.css'
+
+export default function VerifyEmailForm() {
+  const router = useRouter()
+
+  const [currentUser, setCurrentUser] = useState<User | null | undefined>(undefined)
+  const [resendStatus, setResendStatus] = useState<string | null>(null)
+  const [checkError, setCheckError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+  const [checking, setChecking] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      // Auto-redirect if already verified (e.g. user returns to this tab after clicking the link)
+      if (user?.emailVerified) {
+        user.getIdToken(true).then((freshToken) => createSession(freshToken)).then(() => {
+          router.push('/bookings')
+        }).catch(() => {
+          setCurrentUser(user)
+        })
+      } else {
+        setCurrentUser(user)
+      }
+    })
+    return unsubscribe
+  }, [router])
+
+  if (currentUser === undefined) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>VERIFY EMAIL</h1>
+        </div>
+      </div>
+    )
+  }
+
+  if (currentUser === null) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>VERIFY EMAIL</h1>
+          <p className={styles.footer}>
+            <Link href="/login">Sign in to continue</Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  async function handleResend() {
+    if (!currentUser) return
+    setSending(true)
+    setResendStatus(null)
+    try {
+      await sendEmailVerification(currentUser)
+      setResendStatus('Verification email sent')
+    } catch (err) {
+      const code = (err as { code?: string }).code ?? ''
+      if (code === 'auth/too-many-requests') {
+        setResendStatus('Too many attempts. Wait a moment and try again.')
+      } else {
+        setResendStatus('Something went wrong. Please try again.')
+      }
+    } finally {
+      setSending(false)
+    }
+  }
+
+  async function handleContinue() {
+    if (!currentUser) return
+    setChecking(true)
+    setCheckError(null)
+    try {
+      await currentUser.reload()
+      const reloaded = auth.currentUser
+      if (!reloaded) {
+        setCheckError('Session expired. Please sign in again.')
+        return
+      }
+      if (!reloaded.emailVerified) {
+        setCheckError("Your email hasn't been verified yet. Check your inbox.")
+        return
+      }
+      const freshToken = await reloaded.getIdToken(true)
+      await createSession(freshToken)
+      router.push('/bookings')
+    } catch {
+      setCheckError('Something went wrong. Please try again.')
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.formCard}>
+        <h1 className={styles.pageTitle}>VERIFY EMAIL</h1>
+
+        <p>
+          We sent a verification link to <strong>{currentUser.email}</strong>.
+          Check your inbox and click the link to continue.
+        </p>
+
+        {resendStatus && (
+          <div className={styles.status} role="status" aria-live="polite">
+            {resendStatus}
+          </div>
+        )}
+
+        {checkError && (
+          <div className={styles.error} role="alert" aria-live="assertive">
+            {checkError}
+          </div>
+        )}
+
+        <button
+          className={styles.submitBtn}
+          onClick={handleContinue}
+          disabled={checking || sending}
+        >
+          {checking ? 'Checking…' : "I've verified, continue"}
+        </button>
+
+        <button
+          className={styles.submitBtn}
+          onClick={handleResend}
+          disabled={sending || checking}
+        >
+          {sending ? 'Sending…' : 'Resend email'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/lib/dal.ts
+++ b/lib/dal.ts
@@ -34,6 +34,11 @@ export const getVerifiedSession = cache(async (): Promise<SessionClaims> => {
       redirect('/login')
     }
 
+    if (decoded['email_verified'] === false) {
+      console.error('[dal] session_email_unverified')
+      redirect('/verify-email')
+    }
+
     const claims: SessionClaims = {
       uid:             decoded.uid,
       email:           decoded.email ?? '',
@@ -42,7 +47,13 @@ export const getVerifiedSession = cache(async (): Promise<SessionClaims> => {
     }
 
     return claims
-  } catch {
+  } catch (err) {
+    // Re-throw Next.js redirect errors so they propagate to the framework.
+    // In production, redirect() throws an error with a NEXT_REDIRECT digest.
+    // In test, the mock throws Error('REDIRECT:…'). Both must pass through.
+    const digest = (err as { digest?: string }).digest ?? ''
+    const msg    = err instanceof Error ? err.message : ''
+    if (digest.startsWith('NEXT_REDIRECT') || msg.startsWith('REDIRECT:')) throw err
     // Do not log the raw error — Firebase session errors can contain tokens or emails.
     console.error('[dal] session_cookie_invalid')
     redirect('/login')


### PR DESCRIPTION
## Summary
- Sends a Firebase verification email immediately after account creation
- Blocks unverified users server-side in `getVerifiedSession()` — redirects to `/verify-email`
- New `/verify-email` page with resend button and "I've verified, continue" flow that re-issues the session cookie with updated claims
- Login flow also checks `emailVerified` and redirects unverified users to `/verify-email`

## Test plan
- [ ] Create a new account → redirected to `/verify-email`, email arrives from Firebase
- [ ] Try navigating to `/bookings` without verifying → redirected to `/verify-email`
- [ ] Click verification link in email → return to app, click "I've verified, continue" → lands on `/bookings`
- [ ] Sign out, sign in with unverified account → redirected to `/verify-email`
- [ ] Sign out, sign in with verified account → lands on `/bookings`
- [ ] Resend button works; shows rate-limit message if clicked too many times

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)