### PR TITLE
Settings page layout fix

### DIFF
--- a/app/(app)/settings/layout.tsx
+++ b/app/(app)/settings/layout.tsx
@@ -7,7 +7,7 @@ export default async function SettingsLayout({ children }: { children: React.Rea
 
   return (
     <div style={{ maxWidth: '800px', marginLeft: 'auto', marginRight: 'auto' }}>
-      <PageHeader title="SETTINGS" actions={<SettingsSecondaryNav role={session.role} />} />
+      <PageHeader title="SETTINGS" nav={<SettingsSecondaryNav role={session.role} />} />
       {children}
     </div>
   )

--- a/components/nav/PageHeader.module.css
+++ b/components/nav/PageHeader.module.css
@@ -28,3 +28,7 @@
   align-items: center;
   gap: 8px;
 }
+
+.headerWithNav {
+  margin-bottom: 0;
+}

--- a/components/nav/PageHeader.tsx
+++ b/components/nav/PageHeader.tsx
@@ -3,16 +3,17 @@ import styles from './PageHeader.module.css'
 interface PageHeaderProps {
   title: string
   actions?: React.ReactNode
+  nav?: React.ReactNode
 }
 
-export function PageHeader({ title, actions }: PageHeaderProps) {
+export function PageHeader({ title, actions, nav }: PageHeaderProps) {
   return (
-    <header className={styles.header}>
+    <header className={`${styles.header} ${nav ? styles.headerWithNav : ''}`}>
       <div className={styles.top}>
         <h1 className={styles.title}>{title}</h1>
         {actions && <div className={styles.actions}>{actions}</div>}
       </div>
-      <div className={styles.rule} />
+      {nav ?? <div className={styles.rule} />}
     </header>
   )
 }


### PR DESCRIPTION
## Summary
Refactored PageHeader component to support flexible secondary navigation placement. Secondary navigation now renders below the title row instead of being treated as actions.

- Added `nav` prop to PageHeader for explicit navigation element
- Updated settings layout to use the new `nav` prop for SettingsSecondaryNav
- Adjusted styling to remove margin when nav is present

## Test plan
- [ ] Settings page renders correctly with SettingsSecondaryNav below title
- [ ] Layout spacing is correct with nav element present
- [ ] No regressions in other pages using PageHeader

Generated with Claude Code