### PR TITLE
feat(bookings): pick list, edit mode, BookingFormPage extraction

### DIFF
--- a/actions/bookings.ts
+++ b/actions/bookings.ts
@@ -1027,6 +1027,7 @@ export async function getBookedSummary(
   companyId: string,
   startDate: string,
   endDate: string,
+  excludeBookingId?: string,
 ): Promise<Record<string, BookedSummary>> {
   const session = await getVerifiedSession()
   if (companyId !== session.activeCompanyId) return {}
@@ -1051,6 +1052,7 @@ export async function getBookedSummary(
     const summary: Record<string, BookedSummary> = {}
 
     for (const doc of snap.docs) {
+      if (doc.id === excludeBookingId) continue
       const data = doc.data() as StoredBookingForConflict
       if (data.status === 'cancelled') continue
       if (data.approvalStatus === 'rejected') continue

--- a/app/(app)/bookings/[bookingId]/page.tsx
+++ b/app/(app)/bookings/[bookingId]/page.tsx
@@ -3,20 +3,20 @@ import { getVerifiedSession } from '@/lib/dal'
 import { getBooking } from '@/lib/queries/bookings'
 import { getEquipment } from '@/lib/queries/equipment'
 import { getUserProfile } from '@/lib/queries/users'
+import { getCompany } from '@/lib/queries/company'
 import BookingDetail from '@/components/bookings/BookingDetail'
+import BookingFormPage from '@/components/bookings/BookingFormPage'
+import { DEFAULT_COMPANY_PREFERENCES } from '@/constants/company'
 import type { UserProfile } from '@/types'
 
 interface BookingDetailPageProps {
   params: Promise<{ bookingId: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
-/**
- * Booking detail page — Server Component.
- * Fetches booking + active equipment in parallel.
- * Not found → 404.
- */
-export default async function BookingDetailPage({ params }: BookingDetailPageProps) {
+export default async function BookingDetailPage({ params, searchParams }: BookingDetailPageProps) {
   const { bookingId } = await params
+  const sp = await searchParams
   const session = await getVerifiedSession()
 
   const [booking, equipment] = await Promise.all([
@@ -26,7 +26,30 @@ export default async function BookingDetailPage({ params }: BookingDetailPagePro
 
   if (!booking) notFound()
 
-  // Fetch UserProfile for this booking
+  const canEdit =
+    (booking.userId === session.uid || session.role === 'admin') &&
+    (booking.status === 'pending' || booking.status === 'confirmed')
+
+  const wantsEdit = sp['edit'] === '1'
+  const isEditing = wantsEdit && canEdit
+
+  if (isEditing) {
+    const company = await getCompany(session.activeCompanyId)
+    const timeSlotMinutes = company?.preferences?.bookingTimeSlotMinutes ?? DEFAULT_COMPANY_PREFERENCES.bookingTimeSlotMinutes
+
+    return (
+      <BookingFormPage
+        companyId={session.activeCompanyId}
+        equipment={equipment}
+        defaultStartDate={booking.startDate}
+        defaultEndDate={booking.endDate}
+        timeSlotMinutes={timeSlotMinutes}
+        booking={booking}
+        bookingId={booking.id}
+      />
+    )
+  }
+
   let userProfile: UserProfile | null = null
   if (booking.userId) {
     userProfile = await getUserProfile(booking.userId)

--- a/app/(app)/bookings/new/page.tsx
+++ b/app/(app)/bookings/new/page.tsx
@@ -1,10 +1,9 @@
 import { getVerifiedSession } from '@/lib/dal'
 import { getEquipment } from '@/lib/queries/equipment'
 import { getCompany } from '@/lib/queries/company'
-import BookingForm from '@/components/bookings/BookingForm'
+import BookingFormPage from '@/components/bookings/BookingFormPage'
 import { redirect } from 'next/navigation'
 import { DEFAULT_COMPANY_PREFERENCES } from '@/constants/company'
-import styles from './page.module.css'
 
 export default async function NewBookingPage() {
   const session = await getVerifiedSession()
@@ -24,20 +23,12 @@ export default async function NewBookingPage() {
   const timeSlotMinutes = company?.preferences?.bookingTimeSlotMinutes ?? DEFAULT_COMPANY_PREFERENCES.bookingTimeSlotMinutes
 
   return (
-    <main className={styles.main}>
-      <div className={styles.contentWidth}>
-        <header className={styles.header}>
-          <h1 className={styles.h1}>NEW BOOKING</h1>
-          <div className={styles.divider} />
-        </header>
-        <BookingForm
-          companyId={session.activeCompanyId}
-          equipment={equipment}
-          defaultStartDate={todayStr}
-          defaultEndDate={todayStr}
-          timeSlotMinutes={timeSlotMinutes}
-        />
-      </div>
-    </main>
+    <BookingFormPage
+      companyId={session.activeCompanyId}
+      equipment={equipment}
+      defaultStartDate={todayStr}
+      defaultEndDate={todayStr}
+      timeSlotMinutes={timeSlotMinutes}
+    />
   )
 }

--- a/components/bookings/BookingDetail.module.css
+++ b/components/bookings/BookingDetail.module.css
@@ -4,6 +4,8 @@
 
 .container {
   width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 /* Header — no border-bottom per spec */
@@ -85,33 +87,38 @@
   margin-bottom: 24px;
 }
 
-/* Body: stacked on mobile, 2-column on desktop */
+/* Body: column on mobile, row on desktop */
 .body {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 24px;
-  min-height: calc(100vh - 300px);
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
 }
 
 @media (min-width: 768px) {
   .body {
-    grid-template-columns: 1fr 1fr;
+    flex-direction: row;
+    align-items: flex-start;
   }
 }
 
-/* Details column */
+/* -----------------------------------------------------------------------
+   Left column: pick list + ancillary info
+   ----------------------------------------------------------------------- */
+
 .details {
-  background: var(--surface-container-lowest);
-  padding: 32px;
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 32px;
+  padding-bottom: 48px;
 }
 
-/* Equipment list section */
-.equipmentSection {
-  background: var(--surface-container);
-  padding: 32px;
+@media (min-width: 768px) {
+  .details {
+    padding-right: 48px;
+    border-right: 1px solid rgba(255, 255, 255, 0.1);
+    padding-bottom: 0;
+  }
 }
 
 .section {
@@ -138,58 +145,155 @@
   color: var(--error);
 }
 
-/* Equipment items list */
-.itemList {
+/* -----------------------------------------------------------------------
+   Pick List
+   ----------------------------------------------------------------------- */
+
+.pickListHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.pickListProgress {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+
+.pickList {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 0;
 }
 
-.item {
+.pickItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickItem:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickItemInteractive {
+  cursor: pointer;
+}
+
+.pickItemInteractive:hover .pickCheckbox {
+  border-color: rgba(145, 145, 145, 0.7);
+}
+
+/* Custom checkbox */
+.pickCheckbox {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border: 1px solid rgba(145, 145, 145, 0.4);
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  background: var(--surface-container);
-  border-bottom: 1px solid rgba(71, 71, 71, 0.15);
+  justify-content: center;
+  margin-top: 2px;
+  transition: background 0.1s, border-color 0.1s;
 }
 
-.item:last-child {
-  border-bottom: none;
+.pickCheckboxChecked {
+  background: var(--accent);
+  border-color: var(--accent);
 }
 
-.itemName {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--white);
+.pickCheckIcon {
+  font-size: 10px;
+  font-weight: 900;
+  color: var(--on-primary);
+  line-height: 1;
+}
+
+.pickItemContent {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
   flex: 1;
 }
 
-.itemQty {
-  font-size: 12px;
-  font-weight: 700;
+.pickItemName {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--white);
+  line-height: 1.2;
+  transition: opacity 0.1s;
+}
+
+.pickItemNamePicked {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+
+.pickItemMeta {
+  font-size: 11px;
   color: var(--on-surface-variant);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.approvalTag {
-  font-size: 9px;
+.pickItemQty {
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--outline);
-  border: 1px solid rgba(145, 145, 145, 0.3);
-  padding: 2px 6px;
 }
 
-/* Actions column */
+.pickItemUnit {
+  /* inherits meta styles */
+}
+
+/* -----------------------------------------------------------------------
+   Right column: summary + actions
+   ----------------------------------------------------------------------- */
+
 .actions {
-  padding: 32px;
-  background: var(--surface-container-lowest);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 0;
+  padding-bottom: 48px;
 }
+
+@media (min-width: 768px) {
+  .actions {
+    width: 320px;
+    flex-shrink: 0;
+    position: sticky;
+    top: 96px;
+    padding-bottom: 0;
+  }
+}
+
+.actionSection {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.actionSection:first-child {
+  padding-top: 0;
+}
+
+.actionDivider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  margin: 8px 0 16px;
+}
+
+/* -----------------------------------------------------------------------
+   Action buttons (unchanged styles, moved to right column)
+   ----------------------------------------------------------------------- */
 
 /* Approval section */
 .approvalSection {
@@ -333,6 +437,7 @@
   width: 100%;
   text-align: left;
   transition: color 0.1s, border-color 0.1s;
+  margin-top: 8px;
 }
 
 .cancelBtn:not(:disabled):hover {
@@ -359,6 +464,7 @@
   text-align: left;
   cursor: pointer;
   transition: opacity 0.1s;
+  margin-top: 8px;
 }
 
 .checkOutBtn:not(:disabled):hover {
@@ -384,6 +490,7 @@
   text-align: left;
   cursor: pointer;
   transition: opacity 0.1s;
+  margin-top: 8px;
 }
 
 .checkInBtn:not(:disabled):hover {
@@ -393,4 +500,15 @@
 .checkInBtn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Legacy — kept for backward compat with approval tag in pick list area */
+.approvalTag {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--outline);
+  border: 1px solid rgba(145, 145, 145, 0.3);
+  padding: 2px 6px;
 }

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -32,6 +32,7 @@ export default function BookingDetail({
   const [actionError, setActionError] = useState<string | null>(null)
   const [showRejectForm, setShowRejectForm] = useState(false)
   const [rejectionReason, setRejectionReason] = useState('')
+  const [pickedItems, setPickedItems] = useState<Set<string>>(new Set())
 
   const isOwner  = booking.userId === sessionUid
   const isAdmin  = role === 'admin'
@@ -47,6 +48,9 @@ export default function BookingDetail({
     (isAdmin || booking.approverId === sessionUid) &&
     booking.status === 'pending' &&
     booking.approvalStatus === 'pending'
+
+  const canPickList =
+    booking.status === 'confirmed' || booking.status === 'checked_out'
 
   // ---------------------------------------------------------------------------
   // Handlers
@@ -113,6 +117,18 @@ export default function BookingDetail({
     })
   }
 
+  function togglePickedItem(key: string) {
+    setPickedItems((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
   // ---------------------------------------------------------------------------
   // Equipment lookup
   // ---------------------------------------------------------------------------
@@ -150,7 +166,7 @@ export default function BookingDetail({
       <div className={styles.header}>
         <div className={styles.headerLeft}>
           <Link href="/bookings" className={styles.backLink}>
-            ← Bookings
+            &larr; Bookings
           </Link>
           <h1 className={styles.title}>{booking.projectName}</h1>
           <div className={styles.meta}>
@@ -166,7 +182,7 @@ export default function BookingDetail({
         <div className={styles.headerRight}>
           {canEdit && (
             <Link
-              href={`/bookings/${booking.id}/edit`}
+              href={`/bookings/${booking.id}?edit=1`}
               className={styles.editLink}
             >
               Edit
@@ -180,46 +196,63 @@ export default function BookingDetail({
       )}
 
       <div className={styles.body}>
-        {/* Details */}
+        {/* Left column: pick list + ancillary info */}
         <div className={styles.details}>
-          {/* Dates */}
+          {/* Pick List */}
           <div className={styles.section}>
-            <div className={styles.sectionLabel}>Date Range</div>
-            <div className={styles.sectionValue}>{dateRange}</div>
-          </div>
-
-          {/* Equipment list */}
-          <div className={styles.section}>
-            <div className={styles.sectionLabel}>
-              Equipment ({booking.items.length})
+            <div className={styles.pickListHeader}>
+              <div className={styles.sectionLabel}>Pick List</div>
+              {canPickList && (
+                <div className={styles.pickListProgress}>
+                  {pickedItems.size} / {booking.items.length} items
+                </div>
+              )}
             </div>
-            <ul className={styles.itemList}>
+            <ul className={styles.pickList}>
               {booking.items.map((item, index) => {
+                const key = `${item.equipmentId}-${index}`
                 const eq = findEquipment(item.equipmentId)
+                const isPicked = pickedItems.has(key)
+                const unit = eq?.units?.find((u) => u.id === item.unitId) ?? null
+
                 return (
-                  <li key={`${item.equipmentId}-${index}`} className={styles.item}>
-                    <span className={styles.itemName}>
-                      {eq?.name ?? item.equipmentId}
+                  <li
+                    key={key}
+                    className={`${styles.pickItem} ${canPickList ? styles.pickItemInteractive : ''}`}
+                    onClick={() => canPickList && togglePickedItem(key)}
+                  >
+                    <span
+                      className={`${styles.pickCheckbox} ${isPicked ? styles.pickCheckboxChecked : ''}`}
+                      aria-hidden="true"
+                    >
+                      {isPicked && <span className={styles.pickCheckIcon}>&#10003;</span>}
                     </span>
-                    <span className={styles.itemQty}>
-                      {item.quantity > 1 ? `×${item.quantity}` : ''}
+                    <span className={styles.pickItemContent}>
+                      <span
+                        className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
+                      >
+                        {eq?.name ?? item.equipmentId}
+                      </span>
+                      <span className={styles.pickItemMeta}>
+                        {eq?.category ?? ''}
+                        {eq?.trackingType === 'quantity' && item.quantity > 1
+                          ? <span className={styles.pickItemQty}>&times;{item.quantity}</span>
+                          : null}
+                        {eq?.trackingType === 'serialized' && unit
+                          ? (
+                            <span className={styles.pickItemUnit}>
+                              {unit.label}
+                              {unit.serialNumber ? ` · ${unit.serialNumber}` : ''}
+                            </span>
+                          )
+                          : null}
+                      </span>
                     </span>
-                    {eq?.requiresApproval && (
-                      <span className={styles.approvalTag}>Requires approval</span>
-                    )}
                   </li>
                 )
               })}
             </ul>
           </div>
-
-          {/* Notes */}
-          {booking.notes && (
-            <div className={styles.section}>
-              <div className={styles.sectionLabel}>Notes</div>
-              <div className={styles.sectionValue}>{booking.notes}</div>
-            </div>
-          )}
 
           {/* Rejection reason */}
           {booking.approvalStatus === 'rejected' && booking.rejectionReason && (
@@ -260,8 +293,34 @@ export default function BookingDetail({
           </div>
         </div>
 
-        {/* Actions panel */}
+        {/* Right column: summary + actions */}
         <div className={styles.actions}>
+          {/* Date range */}
+          <div className={styles.actionSection}>
+            <div className={styles.sectionLabel}>Date Range</div>
+            <div className={styles.sectionValue}>{dateRange}</div>
+          </div>
+
+          {/* Time */}
+          {(booking.startTime || booking.endTime) && (
+            <div className={styles.actionSection}>
+              <div className={styles.sectionLabel}>Time</div>
+              <div className={styles.sectionValue}>
+                {booking.startTime ?? '—'} &rarr; {booking.endTime ?? '—'}
+              </div>
+            </div>
+          )}
+
+          {/* Notes */}
+          {booking.notes && (
+            <div className={styles.actionSection}>
+              <div className={styles.sectionLabel}>Notes</div>
+              <div className={styles.sectionValue}>{booking.notes}</div>
+            </div>
+          )}
+
+          <div className={styles.actionDivider} />
+
           {/* Approve / Reject — hidden for MVP, re-enable in Phase 5
           {canApprove && (
             <div className={styles.approvalSection}>

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useMemo, useTransition, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { createBooking, checkConflict, getBookedSummary } from '@/actions/bookings'
+import { createBooking, updateBooking, checkConflict, getBookedSummary } from '@/actions/bookings'
 import { useToast } from '@/lib/toast-context'
-import type { Equipment } from '@/types'
+import type { Booking, Equipment } from '@/types'
 import type { ConflictResult, BookedSummary } from '@/actions/bookings'
 import styles from './BookingForm.module.css'
 
@@ -14,6 +14,8 @@ interface BookingFormProps {
   defaultStartDate: string
   defaultEndDate: string
   timeSlotMinutes: number
+  booking?: Booking
+  bookingId?: string
 }
 
 interface SelectedItem {
@@ -50,17 +52,23 @@ export default function BookingForm({
   defaultStartDate,
   defaultEndDate,
   timeSlotMinutes,
+  booking,
+  bookingId,
 }: BookingFormProps) {
   const router = useRouter()
   const { showToast, dismissToast } = useToast()
 
-  const [projectName, setProjectName]   = useState('')
-  const [startDate, setStartDate]       = useState(defaultStartDate)
-  const [endDate, setEndDate]           = useState(defaultEndDate)
-  const [startTime, setStartTime]       = useState('')
-  const [endTime, setEndTime]           = useState('')
-  const [notes, setNotes]               = useState('')
-  const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([])
+  const initialItems: SelectedItem[] = booking
+    ? booking.items.map((i) => ({ equipmentId: i.equipmentId, unitId: i.unitId, quantity: i.quantity }))
+    : []
+
+  const [projectName, setProjectName]   = useState(booking?.projectName ?? '')
+  const [startDate, setStartDate]       = useState(booking?.startDate ?? defaultStartDate)
+  const [endDate, setEndDate]           = useState(booking?.endDate ?? defaultEndDate)
+  const [startTime, setStartTime]       = useState(booking?.startTime ?? '')
+  const [endTime, setEndTime]           = useState(booking?.endTime ?? '')
+  const [notes, setNotes]               = useState(booking?.notes ?? '')
+  const [selectedItems, setSelectedItems] = useState<SelectedItem[]>(initialItems)
   const [error, setError]               = useState<string | null>(null)
   const [conflictResult, setConflictResult] = useState<ConflictResult | null>(null)
   const [isCheckingConflict, setIsCheckingConflict] = useState(false)
@@ -68,11 +76,14 @@ export default function BookingForm({
   const [isLoadingAvailability, setIsLoadingAvailability] = useState(false)
   const [isPending, startTransition]    = useTransition()
 
+  const effectiveStart = booking?.startDate ?? defaultStartDate
+  const effectiveEnd   = booking?.endDate   ?? defaultEndDate
+
   // Load availability on mount (default dates are already set)
   useEffect(() => {
-    if (!defaultStartDate || !defaultEndDate) return
+    if (!effectiveStart || !effectiveEnd) return
     setIsLoadingAvailability(true)
-    getBookedSummary(companyId, defaultStartDate, defaultEndDate)
+    getBookedSummary(companyId, effectiveStart, effectiveEnd, bookingId)
       .then(setBookedSummary)
       .finally(() => setIsLoadingAvailability(false))
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -196,7 +207,7 @@ export default function BookingForm({
 
     // Always refresh availability for all equipment when dates change
     setIsLoadingAvailability(true)
-    getBookedSummary(companyId, newStart, effectiveEnd)
+    getBookedSummary(companyId, newStart, effectiveEnd, bookingId)
       .then(setBookedSummary)
       .finally(() => setIsLoadingAvailability(false))
 
@@ -204,7 +215,7 @@ export default function BookingForm({
     if (selectedItems.length > 0) {
       setIsCheckingConflict(true)
       try {
-        const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems)
+        const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems, bookingId)
         setConflictResult(result)
       } finally {
         setIsCheckingConflict(false)
@@ -238,7 +249,7 @@ export default function BookingForm({
     }
 
     if (startDate && endDate) {
-      const result = await checkConflict(companyId, startDate, endDate, selectedItems)
+      const result = await checkConflict(companyId, startDate, endDate, selectedItems, bookingId)
       setConflictResult(result)
       if (result.hasConflict) {
         setError('Some equipment is unavailable for the selected dates. Review conflicts below.')
@@ -255,18 +266,33 @@ export default function BookingForm({
     formData.set('notes', notes)
     formData.set('items', JSON.stringify(selectedItems))
 
-    const toastId = showToast('saving', 'Saving booking...')
-    startTransition(async () => {
-      const result = await createBooking(formData)
-      dismissToast(toastId)
-      if ('error' in result) {
-        setError(result.error)
-        showToast('error', result.error, 5000)
-      } else {
-        showToast('success', 'Booking created', 3000)
-        router.push(`/bookings/${result.bookingId}`)
-      }
-    })
+    if (bookingId) {
+      const toastId = showToast('saving', 'Saving changes...')
+      startTransition(async () => {
+        const result = await updateBooking(bookingId, formData)
+        dismissToast(toastId)
+        if (result.error) {
+          setError(result.error)
+          showToast('error', result.error, 5000)
+        } else {
+          showToast('success', 'Booking updated', 3000)
+          router.push(`/bookings/${bookingId}`)
+        }
+      })
+    } else {
+      const toastId = showToast('saving', 'Saving booking...')
+      startTransition(async () => {
+        const result = await createBooking(formData)
+        dismissToast(toastId)
+        if ('error' in result) {
+          setError(result.error)
+          showToast('error', result.error, 5000)
+        } else {
+          showToast('success', 'Booking created', 3000)
+          router.push(`/bookings/${result.bookingId}`)
+        }
+      })
+    }
   }
 
   const dateRangeLabel =
@@ -643,7 +669,7 @@ export default function BookingForm({
             className={styles.submitBtn}
             disabled={isPending || isCheckingConflict}
           >
-            {isPending ? 'Saving\u2026' : 'CONFIRM BOOKING'}
+            {isPending ? 'Saving\u2026' : bookingId ? 'UPDATE BOOKING' : 'CONFIRM BOOKING'}
           </button>
         </div>
       </div>

--- a/components/bookings/BookingFormPage.module.css
+++ b/components/bookings/BookingFormPage.module.css
@@ -1,0 +1,36 @@
+.main {
+  padding: 48px 24px 96px;
+  min-height: 100vh;
+}
+
+@media (min-width: 768px) {
+  .main {
+    padding: 64px 24px 64px;
+  }
+}
+
+.contentWidth {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.header {
+  margin-bottom: 48px;
+}
+
+.h1 {
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  color: var(--white);
+  margin-bottom: 24px;
+}
+
+.divider {
+  height: 1px;
+  width: 100%;
+  background: rgba(71, 71, 71, 0.3);
+}

--- a/components/bookings/BookingFormPage.tsx
+++ b/components/bookings/BookingFormPage.tsx
@@ -1,0 +1,43 @@
+import BookingForm from './BookingForm'
+import type { Booking, Equipment } from '@/types'
+import styles from './BookingFormPage.module.css'
+
+interface BookingFormPageProps {
+  companyId: string
+  equipment: Equipment[]
+  defaultStartDate: string
+  defaultEndDate: string
+  timeSlotMinutes: number
+  booking?: Booking
+  bookingId?: string
+}
+
+export default function BookingFormPage({
+  companyId,
+  equipment,
+  defaultStartDate,
+  defaultEndDate,
+  timeSlotMinutes,
+  booking,
+  bookingId,
+}: BookingFormPageProps) {
+  return (
+    <main className={styles.main}>
+      <div className={styles.contentWidth}>
+        <header className={styles.header}>
+          <h1 className={styles.h1}>BOOKING</h1>
+          <div className={styles.divider} />
+        </header>
+        <BookingForm
+          companyId={companyId}
+          equipment={equipment}
+          defaultStartDate={defaultStartDate}
+          defaultEndDate={defaultEndDate}
+          timeSlotMinutes={timeSlotMinutes}
+          booking={booking}
+          bookingId={bookingId}
+        />
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- **BookingDetail redesign**: Interactive pick list where admins check off equipment before checkout, 800px max-width matching new booking, sticky 320px actions sidebar with date summary
- **BookingFormPage**: Extracted shared page wrapper (header + max-width layout) used by both new booking and edit mode (`?edit=1`)
- **Conflict fix**: `getBookedSummary` now accepts `excludeBookingId` so editing a booking doesn't flag itself as a conflict

## Test plan

- [ ] Open a confirmed booking as admin → pick list shows with interactive checkboxes, progress counter updates
- [ ] Open a pending/cancelled booking → pick list shows without checkboxes
- [ ] Check Out and Cancel buttons still work
- [ ] Edit a booking (`?edit=1`) → BookingFormPage loads pre-filled, no self-conflict
- [ ] New booking page renders correctly
- [ ] Verify 800px width on desktop (centered), stacked on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)