### PR TITLE
fix(indexes): add (status, endDate) composite index (#115)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,14 @@
       ]
     },
     {
+      "collectionGroup": "bookings",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "endDate", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "equipment",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Problem

`autoBookingStatusUpdate` queries bookings via `collectionGroup('bookings').where('status', '==', 'checked_out')`. Issue #102 will add `.where('endDate', '<=', todayStr)` to this query to push filtering into Firestore rather than doing it in application code. That compound query (`status` + `endDate` range) requires a composite index on `bookings` with `COLLECTION_GROUP` scope.

The `(status, startDate)` index already existed for the parallel checkout query, but no equivalent index existed for `endDate`.

## Change

Added the missing composite index to `firestore.indexes.json`:

```json
{
  "collectionGroup": "bookings",
  "queryScope": "COLLECTION_GROUP",
  "fields": [
    { "fieldPath": "status", "order": "ASCENDING" },
    { "fieldPath": "endDate", "order": "ASCENDING" }
  ]
}
```

## Deployment note

This index **must be deployed and finish building** before the #102 changes to `autoBookingStatusUpdate` are deployed. Deploying the function without the index in place will cause the scheduled function to throw a `FAILED_PRECONDITION` error on every execution until the index is ready.

Deploy order: `firebase deploy --only firestore:indexes` first, wait for the index to reach `READY` state in the Firebase console, then deploy functions.

Closes #115