### PR TITLE
fix(functions): bound autoStatusUpdate queries by date (#102)

### DIFF
--- a/functions/src/bookings/autoStatusUpdate.ts
+++ b/functions/src/bookings/autoStatusUpdate.ts
@@ -28,18 +28,17 @@ export const autoBookingStatusUpdate = onSchedule(
       return prefs;
     }
 
-    // UTC date string used as an upper-bound filter on both queries.
-    // Bookings whose start/end date is strictly in the future (UTC) cannot be
-    // due in any timezone, so we can safely exclude them at the query level.
-    // Per-company timezone logic in the loop below remains the source of truth
-    // for the exact transition time.
-    const utcTodayStr = new Date().toLocaleDateString('sv-SE', { timeZone: 'UTC' });
+    // Conservative pre-filter: UTC tomorrow covers all timezones (max offset is UTC+14).
+    // The per-company timezone check inside the loop is the authoritative gate.
+    const tomorrow = new Date()
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+    const tomorrowUTCStr = tomorrow.toISOString().slice(0, 10) // 'YYYY-MM-DD'
 
     // ── Auto Checkout: confirmed → checked_out at startDate/startTime ──────────
     const confirmedSnap = await db
       .collectionGroup('bookings')
       .where('status', '==', 'confirmed')
-      .where('startDate', '<=', utcTodayStr)
+      .where('startDate', '<=', tomorrowUTCStr)
       .get();
 
     const checkoutUpdates: Promise<unknown>[] = [];
@@ -72,7 +71,7 @@ export const autoBookingStatusUpdate = onSchedule(
     const checkedOutSnap = await db
       .collectionGroup('bookings')
       .where('status', '==', 'checked_out')
-      .where('endDate', '<=', utcTodayStr)
+      .where('endDate', '<=', tomorrowUTCStr)
       .get();
 
     const checkinUpdates: Promise<unknown>[] = [];

--- a/functions/src/bookings/autoStatusUpdate.ts
+++ b/functions/src/bookings/autoStatusUpdate.ts
@@ -28,10 +28,18 @@ export const autoBookingStatusUpdate = onSchedule(
       return prefs;
     }
 
+    // UTC date string used as an upper-bound filter on both queries.
+    // Bookings whose start/end date is strictly in the future (UTC) cannot be
+    // due in any timezone, so we can safely exclude them at the query level.
+    // Per-company timezone logic in the loop below remains the source of truth
+    // for the exact transition time.
+    const utcTodayStr = new Date().toLocaleDateString('sv-SE', { timeZone: 'UTC' });
+
     // ── Auto Checkout: confirmed → checked_out at startDate/startTime ──────────
     const confirmedSnap = await db
       .collectionGroup('bookings')
       .where('status', '==', 'confirmed')
+      .where('startDate', '<=', utcTodayStr)
       .get();
 
     const checkoutUpdates: Promise<unknown>[] = [];
@@ -64,6 +72,7 @@ export const autoBookingStatusUpdate = onSchedule(
     const checkedOutSnap = await db
       .collectionGroup('bookings')
       .where('status', '==', 'checked_out')
+      .where('endDate', '<=', utcTodayStr)
       .get();
 
     const checkinUpdates: Promise<unknown>[] = [];


### PR DESCRIPTION
## What was the bug

`autoBookingStatusUpdate` issued two platform-wide `collectionGroup('bookings')` queries — one for `status == 'confirmed'` and one for `status == 'checked_out'` — with no date filter. Every 5 minutes the function read every confirmed and every checked-out booking across all companies in Firestore. As the platform grows this causes unbounded read costs and will eventually hit the Cloud Function's 9-minute timeout.

## The fix

A single UTC date string (`utcTodayStr`) is computed once per invocation using `sv-SE` locale formatting (produces `YYYY-MM-DD`, identical to the per-booking date fields). It is applied as an upper-bound filter on both queries:

- Checkout query: `.where('startDate', '<=', utcTodayStr)` — confirmed bookings whose start date is in the future cannot possibly be due yet in any timezone.
- Checkin query: `.where('endDate', '<=', utcTodayStr)` — checked-out bookings whose end date is in the future cannot possibly be overdue yet in any timezone.

The existing per-company timezone re-check in each loop iteration is unchanged and remains the authoritative gate for the exact transition time. The new query filters only eliminate the provably-irrelevant tail, not the timezone edge cases.

## Index dependency

⚠️ Requires the `(status, endDate)` collectionGroup index from #115 to be built and **READY** in the Firestore Console before this function is deployed. The checkout query uses `(status, startDate)` — verify that index is also present in `firestore.indexes.json` from #115, or add it if missing.

Closes #102