### PR TITLE
fix(auth): revoke refresh tokens on switchCompany (#103)

### DIFF
--- a/__tests__/auth/session.test.ts
+++ b/__tests__/auth/session.test.ts
@@ -7,6 +7,8 @@
  *     from the decoded claims.
  *   - createSession (actions/auth.ts): throws when verifyIdToken rejects,
  *     and sets the __session cookie on a valid token.
+ *   - switchCompany (actions/auth.ts): revokes refresh tokens after a
+ *     successful switch; does NOT revoke when membership is missing.
  *
  * Firebase Admin and Next.js cookies/redirect are fully mocked.
  * All spies are created via vi.hoisted() so they are available inside
@@ -21,6 +23,9 @@ const {
   mockVerifySessionCookie,
   mockVerifyIdToken,
   mockCreateSessionCookie,
+  mockSetCustomUserClaims,
+  mockRevokeRefreshTokens,
+  mockMembershipGet,
   mockCookieGet,
   mockCookieSet,
   mockCookieDelete,
@@ -28,6 +33,9 @@ const {
   mockVerifySessionCookie:  vi.fn(),
   mockVerifyIdToken:        vi.fn(),
   mockCreateSessionCookie:  vi.fn(),
+  mockSetCustomUserClaims:  vi.fn(),
+  mockRevokeRefreshTokens:  vi.fn(),
+  mockMembershipGet:        vi.fn(),
   mockCookieGet:            vi.fn(),
   mockCookieSet:            vi.fn(),
   mockCookieDelete:         vi.fn(),
@@ -35,17 +43,27 @@ const {
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-vi.mock('@/lib/firebase-admin', () => ({
-  adminAuth: {
-    verifySessionCookie: mockVerifySessionCookie,
-    verifyIdToken:       mockVerifyIdToken,
-    createSessionCookie: mockCreateSessionCookie,
-  },
-  adminDb: {
-    doc:        vi.fn(),
-    collection: vi.fn(),
-  },
-}))
+vi.mock('@/lib/firebase-admin', () => {
+  // Chainable Firestore stub: collection().doc().collection().doc().get()
+  const membershipDocRef   = { get: mockMembershipGet }
+  const membershipColRef   = { doc: vi.fn().mockReturnValue(membershipDocRef) }
+  const userDocRef         = { collection: vi.fn().mockReturnValue(membershipColRef) }
+  const usersCollectionRef = { doc: vi.fn().mockReturnValue(userDocRef) }
+
+  return {
+    adminAuth: {
+      verifySessionCookie:  mockVerifySessionCookie,
+      verifyIdToken:        mockVerifyIdToken,
+      createSessionCookie:  mockCreateSessionCookie,
+      setCustomUserClaims:  mockSetCustomUserClaims,
+      revokeRefreshTokens:  mockRevokeRefreshTokens,
+    },
+    adminDb: {
+      doc:        vi.fn(),
+      collection: vi.fn().mockReturnValue(usersCollectionRef),
+    },
+  }
+})
 
 vi.mock('next/headers', () => {
   const store = {
@@ -65,7 +83,7 @@ vi.mock('next/navigation', () => ({
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { getVerifiedSession } from '@/lib/dal'
-import { createSession } from '@/actions/auth'
+import { createSession, switchCompany } from '@/actions/auth'
 
 // ── Tests: getVerifiedSession ─────────────────────────────────────────────────
 //
@@ -293,5 +311,59 @@ describe('createSession', () => {
 
     const cookieOptions = mockCookieSet.mock.calls[0][2] as Record<string, unknown>
     expect(cookieOptions.secure).toBe(false)
+  })
+})
+
+// ── Tests: switchCompany ──────────────────────────────────────────────────────
+//
+// switchCompany sets new custom claims and revokes all refresh tokens so that
+// any outstanding session cookie carrying the old activeCompanyId is immediately
+// invalidated (issue #103).
+
+describe('switchCompany', () => {
+  // Wire getVerifiedSession to return a valid session by default.
+  const VALID_SESSION_COOKIE = 'valid-switch-session-token'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockCookieGet.mockReturnValue({ value: VALID_SESSION_COOKIE })
+    mockVerifySessionCookie.mockResolvedValue({
+      uid:             'user-switch',
+      email:           'switch@example.com',
+      activeCompanyId: 'company-old',
+      role:            'admin',
+      email_verified:  true,
+    })
+
+    mockSetCustomUserClaims.mockResolvedValue(undefined)
+    mockRevokeRefreshTokens.mockResolvedValue(undefined)
+  })
+
+  it('calls revokeRefreshTokens with the correct uid after a successful company switch', async () => {
+    mockMembershipGet.mockResolvedValue({
+      exists: true,
+      data:   () => ({ role: 'admin' }),
+    })
+
+    await switchCompany('company-new')
+
+    expect(mockSetCustomUserClaims).toHaveBeenCalledWith('user-switch', {
+      activeCompanyId: 'company-new',
+      role:            'admin',
+    })
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledOnce()
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledWith('user-switch')
+  })
+
+  it('does NOT call revokeRefreshTokens when the membership document does not exist', async () => {
+    mockMembershipGet.mockResolvedValue({
+      exists: false,
+      data:   () => undefined,
+    })
+
+    await expect(switchCompany('company-nonexistent')).rejects.toThrow('Failed to switch company')
+
+    expect(mockRevokeRefreshTokens).not.toHaveBeenCalled()
   })
 })

--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -156,11 +156,16 @@ export async function deleteSession(): Promise<void> {
  * Validates that a membership document exists for the target companyId before
  * updating claims.
  *
+ * After setting new custom claims, all existing refresh tokens are revoked so
+ * that any outstanding session cookie carrying the old activeCompanyId cannot
+ * be used to verify sessions server-side. Without revocation the stale cookie
+ * remains valid for up to 14 days.
+ *
  * IMPORTANT: After calling this action the caller MUST:
  *   1. Call `auth.currentUser.getIdToken(true)` to force a token refresh
  *   2. Call `createSession(freshIdToken)` to re-issue the session cookie
- * Skipping these steps leaves the session cookie carrying stale claims
- * (old activeCompanyId) until it expires — which is a security defect.
+ * Skipping these steps leaves the client with no valid session cookie and the
+ * user will be redirected to /login on the next server request.
  */
 export async function switchCompany(companyId: string): Promise<void> {
   const session = await getVerifiedSession()
@@ -186,6 +191,12 @@ export async function switchCompany(companyId: string): Promise<void> {
       activeCompanyId: companyId,
       role,
     })
+
+    // Revoke all existing refresh tokens so the old session cookie (which
+    // carries the previous activeCompanyId) is immediately invalidated.
+    // Client must call getIdToken(true) then createSession() after this to
+    // get a valid session cookie.
+    await adminAuth.revokeRefreshTokens(uid)
 
     console.log('[actions/auth]', { uid: uid.slice(0, 8) + '...', companyId, role, action: 'company_switched' })
 


### PR DESCRIPTION
## Problem

`switchCompany` in `actions/auth.ts` called `adminAuth.setCustomUserClaims(uid, claims)` and `revalidatePath` but never revoked the existing `__session` cookie. Because Firebase session cookies are not automatically invalidated when custom claims change, the old cookie — carrying the previous `activeCompanyId` — remained valid for up to **14 days**. During that window, any server-side call to `getVerifiedSession` continued to return the old company's claims, giving the user access to the wrong company's data.

## Fix

After `setCustomUserClaims` succeeds, the action now calls:

```typescript
await adminAuth.revokeRefreshTokens(uid)
```

This immediately invalidates all refresh tokens for the user. Firebase's session-cookie verification (`verifySessionCookie`) checks the token revocation time, so any outstanding cookie minted before the revocation is rejected on the next server request.

## Client contract

After `switchCompany` resolves, the caller **must**:
1. Call `auth.currentUser.getIdToken(true)` to force a fresh ID token with the new claims.
2. Call `createSession(freshIdToken)` to re-issue the `__session` cookie.

Without these two steps the user will be redirected to `/login` on the next server request (the revoked session cookie is rejected). This contract was already documented on the function's JSDoc — it has been updated to reflect the revocation behaviour.

## Tests

Two new test cases added to `__tests__/auth/session.test.ts`:
- `revokeRefreshTokens` is called with the correct `uid` after a successful company switch.
- `revokeRefreshTokens` is **not** called when the membership document does not exist (error path).

All 16 tests pass.

Closes #103