### PR TITLE
fix(indexes): correct (status, startDate) index scope to COLLECTION_GROUP (#129)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -10,7 +10,7 @@
     },
     {
       "collectionGroup": "bookings",
-      "queryScope": "COLLECTION",
+      "queryScope": "COLLECTION_GROUP",
       "fields": [
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "startDate", "order": "ASCENDING" }


### PR DESCRIPTION
## Problemet
`autoBookingStatusUpdate` kör `collectionGroup('bookings')` med filter på `status + startDate`, men det befintliga indexet hade `queryScope: "COLLECTION"`. Firestore kan inte använda ett COLLECTION-index för collectionGroup-queries och faller tillbaka på en full scan.

## Fix
Ändrar `queryScope` från `"COLLECTION"` till `"COLLECTION_GROUP"` på `(status ASC, startDate ASC)`-indexet.

Closes #129