### PR TITLE
fix(stripe): trial period, idempotency, tax, ownership guard

### DIFF
--- a/actions/subscription.ts
+++ b/actions/subscription.ts
@@ -28,12 +28,21 @@ export async function createCheckoutSession(
     let stripeCustomerId: string = companyData.stripeCustomerId ?? ''
 
     if (!stripeCustomerId) {
-      const customer = await stripe.customers.create({
-        email: session.email,
-        metadata: { companyId },
+      const existing = await stripe.customers.search({
+        query: `metadata['companyId']:'${companyId}'`,
+        limit: 1,
       })
-      stripeCustomerId = customer.id
-      await companyRef.update({ stripeCustomerId })
+      if (existing.data.length > 0) {
+        stripeCustomerId = existing.data[0].id
+        await companyRef.update({ stripeCustomerId })
+      } else {
+        const customer = await stripe.customers.create(
+          { email: session.email, name: companyData.name as string | undefined, metadata: { companyId } },
+          { idempotencyKey: `create-customer-${companyId}` },
+        )
+        stripeCustomerId = customer.id
+        await companyRef.update({ stripeCustomerId })
+      }
     }
 
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
@@ -44,10 +53,22 @@ export async function createCheckoutSession(
       allow_promotion_codes: true,
       success_url: `${process.env.NEXT_PUBLIC_APP_URL}/payment-success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/settings/subscription?checkout=canceled`,
+      subscription_data: companyData.hadTrial
+        ? undefined
+        : { trial_period_days: 14 },
+      payment_method_collection: 'always',
+      // TODO(#91): Requires Stripe Tax activated in Dashboard + Swedish VAT registration before launch
+      automatic_tax:             { enabled: true },
+      tax_id_collection:         { enabled: true },
+      billing_address_collection: 'required',
+      customer_update:           { address: 'auto', name: 'auto' },
     }
 
     try {
-      const checkoutSession = await stripe.checkout.sessions.create(sessionParams)
+      const checkoutSession = await stripe.checkout.sessions.create(
+        sessionParams,
+        { idempotencyKey: `checkout-${companyId}-${interval}-${Math.floor(Date.now() / 60000)}` },
+      )
       return { url: checkoutSession.url! }
     } catch (err) {
       if (
@@ -55,15 +76,15 @@ export async function createCheckoutSession(
         err.code === 'resource_missing' &&
         err.param === 'customer'
       ) {
-        const newCustomer = await stripe.customers.create({
-          email: session.email,
-          metadata: { companyId },
-        })
+        const newCustomer = await stripe.customers.create(
+          { email: session.email, name: companyData.name as string | undefined, metadata: { companyId } },
+          { idempotencyKey: `create-customer-${companyId}` },
+        )
         await companyRef.update({ stripeCustomerId: newCustomer.id })
-        const retrySession = await stripe.checkout.sessions.create({
-          ...sessionParams,
-          customer: newCustomer.id,
-        })
+        const retrySession = await stripe.checkout.sessions.create(
+          { ...sessionParams, customer: newCustomer.id },
+          { idempotencyKey: `checkout-${companyId}-${interval}-${Math.floor(Date.now() / 60000)}` },
+        )
         return { url: retrySession.url! }
       }
       throw err

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -48,9 +48,21 @@ async function handleCheckoutSessionCompleted(session: Stripe.Checkout.Session) 
     return
   }
 
-  await adminDb.doc(`companies/${companyId}`).update({
-    stripeCustomerId: customerId,
-  })
+  const companyRef = adminDb.doc(`companies/${companyId}`)
+  const companySnap = await companyRef.get()
+  const existingCustomerId = companySnap.data()?.stripeCustomerId as string | undefined
+
+  if (existingCustomerId && existingCustomerId !== customerId) {
+    console.error('[webhooks/stripe]', {
+      action: 'checkout_session_customer_id_mismatch',
+      companyId,
+      existingCustomerId,
+      incomingCustomerId: customerId,
+    })
+    return
+  }
+
+  await companyRef.update({ stripeCustomerId: customerId })
 
   console.log('[webhooks/stripe]', {
     action: 'checkout_session_completed',


### PR DESCRIPTION
## Summary

Fixes seven open Stripe/GDPR issues in the subscription flow.

- **#81** — 14-day trial added via `subscription_data.trial_period_days`; skipped when `hadTrial` is already set
- **#86** — `stripe.customers.search` guard before `customers.create` prevents orphan duplicates; idempotency key added
- **#91** — `automatic_tax`, `tax_id_collection`, `billing_address_collection`, `customer_update` enabled on checkout session
- **#93** — `handleCheckoutSessionCompleted` reads existing `stripeCustomerId` and bails with an error log if there's a mismatch
- **#100** — Confirmed no code change needed; single-write was already established by the #96 refactor
- **#104** — Minute-bucketed idempotency key on `checkout.sessions.create` prevents duplicate sessions on double-click
- **#112** — `companyData.name` passed to `stripe.customers.create` to reduce reliance on personal email as sole identifier

## ⚠️ Required before this goes live

Issue #91 (`automatic_tax: { enabled: true }`) **requires Stripe Tax to be activated in the Stripe Dashboard** and a Swedish VAT number registered. Without this the checkout will error. A TODO comment marks the relevant lines.

## Test plan

- [ ] New company subscribe flow: checkout shows 14-day trial, collects billing address and tax ID
- [ ] Returning company with `hadTrial: true`: no trial offered
- [ ] Double-click subscribe: only one Stripe customer + one session created
- [ ] `stripe trigger checkout.session.completed` with same `companyId`, different `customerId`: mismatch logged, no overwrite
- [ ] `npx tsc --noEmit`: no new errors (18 pre-existing errors in test mocks, unrelated)
- [ ] Stripe Dashboard: activate Stripe Tax + register SE VAT before deploying to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)