### PR TITLE
fix(gdpr): sanitise Stripe error logs and truncate UID in setActiveClaim

### DIFF
--- a/actions/subscription.ts
+++ b/actions/subscription.ts
@@ -90,7 +90,11 @@ export async function createCheckoutSession(
       throw err
     }
   } catch (err) {
-    console.error('[actions/subscription] create_checkout_session_error', err)
+    console.error('[actions/subscription]', {
+      action: 'create_checkout_session_error',
+      message: err instanceof Error ? err.message : String(err),
+      code: err instanceof Stripe.errors.StripeError ? err.code : undefined,
+    })
     return { error: 'Could not create checkout session' }
   }
 }

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -268,7 +268,11 @@ export async function POST(request: NextRequest) {
   try {
     event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret)
   } catch (err) {
-    console.error('[webhooks/stripe]', { error: 'Signature verification failed', err })
+    console.error('[webhooks/stripe]', {
+      error: 'Signature verification failed',
+      message: err instanceof Error ? err.message : String(err),
+      code: err instanceof Stripe.errors.StripeError ? err.code : undefined,
+    })
     return NextResponse.json({ error: 'Webhook signature verification failed' }, { status: 400 })
   }
 

--- a/functions/src/auth/setActiveClaim.ts
+++ b/functions/src/auth/setActiveClaim.ts
@@ -55,7 +55,7 @@ export const setActiveClaim = onCall({ region: 'europe-west1', cors: true, invok
   // server-side reads can use it without decoding the JWT.
   await db.doc(`users/${uid}`).update({ activeCompanyId: companyId });
 
-  logger.info('setActiveClaim: claim updated', { uid, companyId, role });
+  logger.info('setActiveClaim: claim updated', { uid: uid.slice(0, 8) + '...', companyId, role });
 
   return { success: true };
 });


### PR DESCRIPTION
## Summary

- **#101** — Replace raw `err` objects in `console.error` calls with sanitised shape `{ message, code }`. Stripe SDK errors can contain request payloads with customer emails and partial card metadata; Vercel logs are not EU-bound by default.
- **#114** — Truncate UID to 8 chars in `setActiveClaim` log, matching every other Cloud Function in the codebase. UIDs are PII under GDPR (linkable to `/users/{uid}`).

## Files changed

- `app/api/webhooks/stripe/route.ts` — signature verification catch now logs only `message` + `code`
- `actions/subscription.ts` — outer checkout session catch now logs only `message` + `code`
- `functions/src/auth/setActiveClaim.ts` — `uid` → `uid.slice(0, 8) + '...'`

## Test plan

- [x] `npx tsc --noEmit` in repo root — no new errors (pre-existing test-mock errors unchanged)
- [x] `npx tsc --noEmit` in `functions/` — clean
- [x] Manual grep confirms no raw `err` object passed to any logger in changed files

Closes #101
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)