### PR TITLE
fix: same-day timed bookings no longer block non-overlapping slots

### DIFF
--- a/actions/bookings.ts
+++ b/actions/bookings.ts
@@ -30,6 +30,8 @@ interface BookingDocumentInternal {
   equipmentIds: string[]
   startDate: string
   endDate: string
+  startTime?: string | null
+  endTime?: string | null
   userId: string | null
   status: string
   requiresApproval: boolean
@@ -61,10 +63,27 @@ interface ConflictResultInternal {
 interface StoredBookingForConflict {
   startDate: string
   endDate: string
+  startTime?: string | null
+  endTime?: string | null
   status: string
   approvalStatus: string
   items: BookingItem[]
   equipmentIds: string[]
+}
+
+/**
+ * Returns false only when both bookings are same-day with explicit time windows
+ * that do not overlap. In all other cases returns true (conservative).
+ */
+function timesOverlap(
+  a: { startDate: string; endDate: string; startTime?: string | null; endTime?: string | null },
+  b: { startDate: string; endDate: string; startTime?: string | null; endTime?: string | null },
+): boolean {
+  // Time-based exclusion only applies to same-day bookings with explicit times
+  if (a.startDate !== a.endDate || b.startDate !== b.endDate) return true
+  if (a.startDate !== b.startDate) return true
+  if (!a.startTime || !a.endTime || !b.startTime || !b.endTime) return true
+  return a.startTime < b.endTime && b.startTime < a.endTime
 }
 
 /**
@@ -124,6 +143,8 @@ async function detectConflictsReadOnly(
   startDate: string,
   endDate: string,
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<ConflictResultInternal> {
   const conflicts: ConflictDetailInternal[] = []
   const bookingsRef = db.collection(`companies/${companyId}/bookings`)
@@ -174,12 +195,14 @@ async function detectConflictsReadOnly(
         .where('endDate', '>=', startDate)
         .get()
 
+      const requested = { startDate, endDate, startTime, endTime }
       const overlapping = unitQuery.docs.filter((doc) => {
         if (doc.id === excludeBookingId) return false
         const data = doc.data() as StoredBookingForConflict
         if (data.status === 'cancelled') return false
         if (data.approvalStatus === 'rejected') return false
-        return data.startDate <= endDate
+        if (data.startDate > endDate) return false
+        return timesOverlap(requested, data)
       })
 
       if (overlapping.length > 0) {
@@ -199,12 +222,14 @@ async function detectConflictsReadOnly(
         .where('endDate', '>=', startDate)
         .get()
 
+      const requested = { startDate, endDate, startTime, endTime }
       const overlapping = eqQuery.docs.filter((doc) => {
         if (doc.id === excludeBookingId) return false
         const data = doc.data() as StoredBookingForConflict
         if (data.status === 'cancelled') return false
         if (data.approvalStatus === 'rejected') return false
-        return data.startDate <= endDate
+        if (data.startDate > endDate) return false
+        return timesOverlap(requested, data)
       })
 
       let sumBooked = 0
@@ -242,6 +267,8 @@ async function detectConflictsInTransaction(
   startDate: string,
   endDate: string,
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<ConflictResultInternal> {
   const conflicts: ConflictDetailInternal[] = []
   const bookingsRef = db.collection(`companies/${companyId}/bookings`)
@@ -290,12 +317,14 @@ async function detectConflictsInTransaction(
 
       const unitQuerySnap = await tx.get(unitQuery)
 
+      const requestedUnit = { startDate, endDate, startTime, endTime }
       const overlapping = unitQuerySnap.docs.filter((doc) => {
         if (doc.id === excludeBookingId) return false
         const data = doc.data() as StoredBookingForConflict
         if (data.status === 'cancelled') return false
         if (data.approvalStatus === 'rejected') return false
-        return data.startDate <= endDate
+        if (data.startDate > endDate) return false
+        return timesOverlap(requestedUnit, data)
       })
 
       if (overlapping.length > 0) {
@@ -314,12 +343,14 @@ async function detectConflictsInTransaction(
 
       const querySnap = await tx.get(eqQuery)
 
+      const requestedQty = { startDate, endDate, startTime, endTime }
       const overlapping = querySnap.docs.filter((doc) => {
         if (doc.id === excludeBookingId) return false
         const data = doc.data() as StoredBookingForConflict
         if (data.status === 'cancelled') return false
         if (data.approvalStatus === 'rejected') return false
-        return data.startDate <= endDate
+        if (data.startDate > endDate) return false
+        return timesOverlap(requestedQty, data)
       })
 
       let sumBooked = 0
@@ -488,6 +519,9 @@ export async function createBooking(
         items,
         startDate,
         endDate,
+        undefined,
+        startTime,
+        endTime,
       )
 
       if (conflictResult.hasConflict) {
@@ -589,6 +623,28 @@ export async function updateBooking(
     notes = rawNotes
   }
 
+  // Three-value semantics: field absent from FormData = undefined (keep existing),
+  // field present but empty = null (clear to all-day), valid HH:MM = new value.
+  const rawStartTime = formData.get('startTime') as string | null
+  const startTime: string | null | undefined =
+    rawStartTime === null
+      ? undefined
+      : rawStartTime.trim() === ''
+        ? null
+        : /^\d{2}:\d{2}$/.test(rawStartTime.trim())
+          ? rawStartTime.trim()
+          : null
+
+  const rawEndTime = formData.get('endTime') as string | null
+  const endTime: string | null | undefined =
+    rawEndTime === null
+      ? undefined
+      : rawEndTime.trim() === ''
+        ? null
+        : /^\d{2}:\d{2}$/.test(rawEndTime.trim())
+          ? rawEndTime.trim()
+          : null
+
   const itemsRaw = formData.get('items') as string | null
   let items: BookingItem[] | undefined
   if (itemsRaw) {
@@ -627,6 +683,8 @@ export async function updateBooking(
       const effectiveItems = items ?? booking.items
       const effectiveStartDate = startDate ?? booking.startDate
       const effectiveEndDate = endDate ?? booking.endDate
+      const effectiveStartTime = startTime === undefined ? (booking.startTime ?? null) : startTime
+      const effectiveEndTime = endTime === undefined ? (booking.endTime ?? null) : endTime
 
       if (effectiveEndDate < effectiveStartDate) {
         throw new Error('endDate must be on or after startDate.')
@@ -678,8 +736,12 @@ export async function updateBooking(
         }
       }
 
-      // ── Conflict detection if dates or items changed ───────────────────────
-      const datesChanged = startDate !== undefined || endDate !== undefined
+      // ── Conflict detection if dates, times, or items changed ─────────────────
+      const datesChanged =
+        startDate !== undefined ||
+        endDate !== undefined ||
+        startTime !== undefined ||
+        endTime !== undefined
       const itemsChanged = items !== undefined
 
       if (datesChanged || itemsChanged) {
@@ -691,6 +753,8 @@ export async function updateBooking(
           effectiveStartDate,
           effectiveEndDate,
           bookingId,
+          effectiveStartTime,
+          effectiveEndTime,
         )
 
         if (conflictResult.hasConflict) {
@@ -709,6 +773,8 @@ export async function updateBooking(
       if (notes !== undefined) updateData.notes = notes
       if (startDate !== undefined) updateData.startDate = startDate
       if (endDate !== undefined) updateData.endDate = endDate
+      if (startTime !== undefined) updateData.startTime = startTime
+      if (endTime !== undefined) updateData.endTime = endTime
       if (items !== undefined) {
         updateData.items = items
         updateData.equipmentIds = extractEquipmentIds(items)
@@ -967,6 +1033,8 @@ export async function approveBooking(
           booking.startDate,
           booking.endDate,
           bookingId,
+          booking.startTime ?? null,
+          booking.endTime ?? null,
         )
 
         if (conflictResult.hasConflict) {
@@ -1024,6 +1092,8 @@ export async function getBookedSummary(
   startDate: string,
   endDate: string,
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<Record<string, BookedSummary>> {
   const session = await getVerifiedSession()
   if (companyId !== session.activeCompanyId) return {}
@@ -1046,13 +1116,15 @@ export async function getBookedSummary(
       .get()
 
     const summary: Record<string, BookedSummary> = {}
+    const requested = { startDate: validatedStart, endDate: validatedEnd, startTime, endTime }
 
     for (const doc of snap.docs) {
       if (doc.id === excludeBookingId) continue
       const data = doc.data() as StoredBookingForConflict
       if (data.status === 'cancelled') continue
       if (data.approvalStatus === 'rejected') continue
-      if (data.startDate > validatedEnd) continue  // no overlap
+      if (data.startDate > validatedEnd) continue  // no date overlap
+      if (!timesOverlap(requested, data)) continue   // same-day non-overlapping time window
 
       for (const item of data.items ?? []) {
         if (!summary[item.equipmentId]) {
@@ -1082,6 +1154,8 @@ export async function checkConflict(
   endDate: string,
   items: BookingItem[],
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<ConflictResult> {
   const session = await getVerifiedSession()
 
@@ -1115,6 +1189,8 @@ export async function checkConflict(
       validatedStart,
       validatedEnd,
       excludeBookingId,
+      startTime,
+      endTime,
     )
 
     // Map internal ConflictDetail to the exported ConflictItem shape.

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -83,11 +83,30 @@ export default function BookingForm({
   useEffect(() => {
     if (!effectiveStart || !effectiveEnd) return
     setIsLoadingAvailability(true)
-    getBookedSummary(companyId, effectiveStart, effectiveEnd, bookingId)
+    getBookedSummary(companyId, effectiveStart, effectiveEnd, bookingId, booking?.startTime ?? null, booking?.endTime ?? null)
       .then(setBookedSummary)
       .finally(() => setIsLoadingAvailability(false))
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Refresh availability + conflicts when the time window changes
+  // (date changes are handled by handleDateChange).
+  useEffect(() => {
+    if (!startDate || !endDate) return
+    const effectiveEnd = endDate < startDate ? startDate : endDate
+    setIsLoadingAvailability(true)
+    getBookedSummary(companyId, startDate, effectiveEnd, bookingId, startTime || null, endTime || null)
+      .then(setBookedSummary)
+      .finally(() => setIsLoadingAvailability(false))
+
+    if (selectedItems.length > 0) {
+      setIsCheckingConflict(true)
+      checkConflict(companyId, startDate, effectiveEnd, selectedItems, bookingId, startTime || null, endTime || null)
+        .then(setConflictResult)
+        .finally(() => setIsCheckingConflict(false))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [startTime, endTime])
 
   const hourOptions   = useMemo(() => generateHourOptions(), [])
   const minuteOptions = useMemo(() => generateMinuteOptions(timeSlotMinutes), [timeSlotMinutes])
@@ -207,7 +226,7 @@ export default function BookingForm({
 
     // Always refresh availability for all equipment when dates change
     setIsLoadingAvailability(true)
-    getBookedSummary(companyId, newStart, effectiveEnd, bookingId)
+    getBookedSummary(companyId, newStart, effectiveEnd, bookingId, startTime || null, endTime || null)
       .then(setBookedSummary)
       .finally(() => setIsLoadingAvailability(false))
 
@@ -215,7 +234,7 @@ export default function BookingForm({
     if (selectedItems.length > 0) {
       setIsCheckingConflict(true)
       try {
-        const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems, bookingId)
+        const result = await checkConflict(companyId, newStart, effectiveEnd, selectedItems, bookingId, startTime || null, endTime || null)
         setConflictResult(result)
       } finally {
         setIsCheckingConflict(false)
@@ -249,7 +268,7 @@ export default function BookingForm({
     }
 
     if (startDate && endDate) {
-      const result = await checkConflict(companyId, startDate, endDate, selectedItems, bookingId)
+      const result = await checkConflict(companyId, startDate, endDate, selectedItems, bookingId, startTime || null, endTime || null)
       setConflictResult(result)
       if (result.hasConflict) {
         setError('Some equipment is unavailable for the selected dates. Review conflicts below.')

--- a/functions/src/bookings/approveBooking.ts
+++ b/functions/src/bookings/approveBooking.ts
@@ -88,6 +88,8 @@ export const approveBooking = onCall({ region: 'europe-west1', cors: true, invok
       booking.startDate,
       booking.endDate,
       bookingId,
+      booking.startTime ?? null,
+      booking.endTime ?? null,
     );
 
     if (conflictResult.hasConflict) {

--- a/functions/src/bookings/checkBookingConflict.ts
+++ b/functions/src/bookings/checkBookingConflict.ts
@@ -65,6 +65,18 @@ export const checkBookingConflict = onCall({ region: 'europe-west1', cors: true,
       ? rawExclude.trim()
       : undefined;
 
+  const rawStartTime: unknown = request.data.startTime;
+  const startTime: string | null =
+    typeof rawStartTime === 'string' && /^\d{2}:\d{2}$/.test(rawStartTime)
+      ? rawStartTime
+      : null;
+
+  const rawEndTime: unknown = request.data.endTime;
+  const endTime: string | null =
+    typeof rawEndTime === 'string' && /^\d{2}:\d{2}$/.test(rawEndTime)
+      ? rawEndTime
+      : null;
+
   // ── Conflict detection ─────────────────────────────────────────────────────
   const db = getFirestore();
   const result = await detectConflictsReadOnly(
@@ -74,6 +86,8 @@ export const checkBookingConflict = onCall({ region: 'europe-west1', cors: true,
     startDate,
     endDate,
     excludeBookingId,
+    startTime,
+    endTime,
   );
 
   return result;

--- a/functions/src/bookings/conflictDetection.ts
+++ b/functions/src/bookings/conflictDetection.ts
@@ -48,10 +48,27 @@ export interface ConflictResult {
 interface StoredBookingForConflict {
   startDate: string;
   endDate: string;
+  startTime?: string | null;
+  endTime?: string | null;
   status: string;
   approvalStatus: string;
   items: BookingItemInput[];
   equipmentIds: string[];
+}
+
+/**
+ * Returns false only when both bookings are same-day with explicit time windows
+ * that do not overlap. In all other cases returns true (conservative).
+ */
+function timesOverlap(
+  a: { startDate: string; endDate: string; startTime?: string | null; endTime?: string | null },
+  b: { startDate: string; endDate: string; startTime?: string | null; endTime?: string | null },
+): boolean {
+  // Time-based exclusion only applies to same-day bookings with explicit times
+  if (a.startDate !== a.endDate || b.startDate !== b.endDate) return true;
+  if (a.startDate !== b.startDate) return true;
+  if (!a.startTime || !a.endTime || !b.startTime || !b.endTime) return true;
+  return a.startTime < b.endTime && b.startTime < a.endTime;
 }
 
 /**
@@ -67,6 +84,8 @@ export async function detectConflictsReadOnly(
   startDate: string,
   endDate: string,
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<ConflictResult> {
   const conflicts: ConflictDetail[] = [];
   const bookingsRef = db.collection(`companies/${companyId}/bookings`);
@@ -97,6 +116,7 @@ export async function detectConflictsReadOnly(
       .where('endDate', '>=', startDate)
       .get();
 
+    const requested = { startDate, endDate, startTime, endTime };
     const overlapping = query.docs.filter((doc) => {
       if (doc.id === excludeBookingId) return false;
       const data = doc.data() as StoredBookingForConflict;
@@ -105,7 +125,8 @@ export async function detectConflictsReadOnly(
       if (data.approvalStatus === 'rejected') return false;
       // The query gives us bookings whose endDate >= requestedStartDate.
       // We also need: booking.startDate <= requestedEndDate.
-      return data.startDate <= endDate;
+      if (data.startDate > endDate) return false;
+      return timesOverlap(requested, data);
     });
 
     if (equipment.trackingType === 'serialized') {
@@ -157,6 +178,8 @@ export async function detectConflictsInTransaction(
   startDate: string,
   endDate: string,
   excludeBookingId?: string,
+  startTime?: string | null,
+  endTime?: string | null,
 ): Promise<ConflictResult> {
   const conflicts: ConflictDetail[] = [];
   const bookingsRef = db.collection(`companies/${companyId}/bookings`);
@@ -183,13 +206,15 @@ export async function detectConflictsInTransaction(
 
     const querySnap = await tx.get(query);
 
+    const requested = { startDate, endDate, startTime, endTime };
     const overlapping = querySnap.docs.filter((doc) => {
       if (doc.id === excludeBookingId) return false;
       const data = doc.data() as StoredBookingForConflict;
       // Cancelled and rejected bookings do not hold equipment — exclude them.
       if (data.status === 'cancelled') return false;
       if (data.approvalStatus === 'rejected') return false;
-      return data.startDate <= endDate;
+      if (data.startDate > endDate) return false;
+      return timesOverlap(requested, data);
     });
 
     if (equipment.trackingType === 'serialized') {

--- a/functions/src/bookings/createBooking.ts
+++ b/functions/src/bookings/createBooking.ts
@@ -94,6 +94,18 @@ export const createBooking = onCall({ region: 'europe-west1', cors: true, invoke
     notes = rawNotes;
   }
 
+  const rawStartTime: unknown = request.data.startTime;
+  const startTime: string | null =
+    typeof rawStartTime === 'string' && /^\d{2}:\d{2}$/.test(rawStartTime)
+      ? rawStartTime
+      : null;
+
+  const rawEndTime: unknown = request.data.endTime;
+  const endTime: string | null =
+    typeof rawEndTime === 'string' && /^\d{2}:\d{2}$/.test(rawEndTime)
+      ? rawEndTime
+      : null;
+
   // ── Transaction ────────────────────────────────────────────────────────────
   const db = getFirestore();
   const uid = request.auth.uid;
@@ -182,6 +194,9 @@ export const createBooking = onCall({ region: 'europe-west1', cors: true, invoke
       items,
       startDate,
       endDate,
+      undefined,
+      startTime,
+      endTime,
     );
 
     if (conflictResult.hasConflict) {
@@ -210,6 +225,8 @@ export const createBooking = onCall({ region: 'europe-west1', cors: true, invoke
       equipmentIds,
       startDate,
       endDate,
+      startTime,
+      endTime,
       userId: uid,
       userName: null,
       status: bookingStatus,

--- a/functions/src/bookings/updateBooking.ts
+++ b/functions/src/bookings/updateBooking.ts
@@ -107,6 +107,28 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
     notes = rawNotes;
   }
 
+  // Three-value semantics: undefined = not sent (keep existing), null = clear to
+  // all-day, string matching HH:MM = new value. Invalid strings are treated as null.
+  const rawStartTime = request.data.startTime;
+  const startTime: string | null | undefined =
+    rawStartTime === undefined
+      ? undefined
+      : rawStartTime === null
+        ? null
+        : typeof rawStartTime === 'string' && /^\d{2}:\d{2}$/.test(rawStartTime)
+          ? rawStartTime
+          : null;
+
+  const rawEndTime = request.data.endTime;
+  const endTime: string | null | undefined =
+    rawEndTime === undefined
+      ? undefined
+      : rawEndTime === null
+        ? null
+        : typeof rawEndTime === 'string' && /^\d{2}:\d{2}$/.test(rawEndTime)
+          ? rawEndTime
+          : null;
+
   const uid = request.auth.uid;
   const isAdmin = request.auth.token.role === 'admin';
   const db = getFirestore();
@@ -138,6 +160,8 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
     const effectiveItems = items ?? booking.items;
     const effectiveStartDate = startDate ?? booking.startDate;
     const effectiveEndDate = endDate ?? booking.endDate;
+    const effectiveStartTime = startTime === undefined ? (booking.startTime ?? null) : startTime;
+    const effectiveEndTime = endTime === undefined ? (booking.endTime ?? null) : endTime;
 
     // Cross-validate final date pair.
     if (effectiveEndDate < effectiveStartDate) {
@@ -195,8 +219,12 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
       }
     }
 
-    // ── Conflict detection if dates or items changed ───────────────────────
-    const datesChanged = startDate !== undefined || endDate !== undefined;
+    // ── Conflict detection if dates, times, or items changed ─────────────────
+    const datesChanged =
+      startDate !== undefined ||
+      endDate !== undefined ||
+      startTime !== undefined ||
+      endTime !== undefined;
     const itemsChanged = items !== undefined;
 
     if (datesChanged || itemsChanged) {
@@ -208,6 +236,8 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
         effectiveStartDate,
         effectiveEndDate,
         bookingId, // exclude this booking from its own conflict check
+        effectiveStartTime,
+        effectiveEndTime,
       );
 
       if (conflictResult.hasConflict) {
@@ -231,6 +261,8 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
     if (notes !== undefined) updateData.notes = notes;
     if (startDate !== undefined) updateData.startDate = startDate;
     if (endDate !== undefined) updateData.endDate = endDate;
+    if (startTime !== undefined) updateData.startTime = startTime;
+    if (endTime !== undefined) updateData.endTime = endTime;
     if (items !== undefined) {
       updateData.items = items;
       updateData.equipmentIds = extractEquipmentIds(items);

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -88,6 +88,8 @@ export interface BookingDocument {
   equipmentIds: string[];          // denormalized flat array for array-contains queries
   startDate: string;               // "YYYY-MM-DD"
   endDate: string;                 // "YYYY-MM-DD"
+  startTime?: string | null;       // "HH:MM" (24-hour), null means all-day
+  endTime?: string | null;         // "HH:MM" (24-hour), null means all-day
   userId: string | null;
   userName: string | null;        // null — not stored; userId is the reference. Resolving name at read time avoids storing PII on the booking document.
   status: BookingStatus;


### PR DESCRIPTION
## Summary

- Conflict detection only compared `startDate`/`endDate` — `startTime`/`endTime` were ignored. A booking at 02:00–04:00 blocked any new booking on the same day.
- Adds `timesOverlap()` helper in both `actions/bookings.ts` and `functions/src/bookings/conflictDetection.ts`. Time-based exclusion only applies when both bookings are single-day, share the same date, and have explicit non-null times that don't intersect. All other cases remain conservative.
- `getBookedSummary` is now time-aware — units booked outside the requested window no longer show as unavailable in the picker.
- `BookingForm.tsx` now passes `startTime`/`endTime` to both `checkConflict` and `getBookedSummary`, and re-runs both when the time selection changes.

## Files changed

- `actions/bookings.ts` — `timesOverlap`, updated signatures + filters, updated `getBookedSummary`
- `components/bookings/BookingForm.tsx` — pass times to conflict/summary calls, new `useEffect` on time changes
- `functions/src/bookings/conflictDetection.ts` — `timesOverlap`, updated signatures + filters
- `functions/src/types.ts` — `startTime?`/`endTime?` on `BookingDocument`
- `functions/src/bookings/checkBookingConflict.ts`, `createBooking.ts`, `updateBooking.ts`, `approveBooking.ts` — parse + forward time params

## Test plan

- [ ] Book a serialized item at 02:00–04:00 today → book same item at 09:00–12:00 same day → should be **allowed**
- [ ] Book same item at 03:00–10:00 same day → should be **blocked**
- [ ] Multi-day booking still blocks all days in the range regardless of time
- [ ] All-day booking (no times) still blocks the whole day
- [ ] `tsc --noEmit` and `npm run build` in `functions/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)