### PR TITLE
fix(auth): persist invited user's name on signup

### DIFF
--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -1,24 +1,97 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
-import { createUserWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
-import { auth } from '@/lib/firebase'
+import { createUserWithEmailAndPassword, sendEmailVerification, updateProfile } from 'firebase/auth'
+import { getFunctions, httpsCallable } from 'firebase/functions'
+import { doc, getDoc } from 'firebase/firestore'
+import { auth, db } from '@/lib/firebase'
 import { setupNewCompany, createSession } from '@/actions/auth'
 import styles from './Auth.module.css'
 
 const MIN_PASSWORD_LENGTH = 8
 
+// Extract invite token from a redirect path like /invite/<token>
+function extractInviteToken(redirect: string | null): string | null {
+  if (!redirect) return null
+  const match = redirect.match(/^\/invite\/([a-zA-Z0-9]{1,40})$/)
+  return match ? match[1] : null
+}
+
 export default function SignupForm() {
-  const router = useRouter()
+  const router       = useRouter()
+  const searchParams = useSearchParams()
+
+  const redirectParam = searchParams.get('redirect')
+  const emailParam    = searchParams.get('email') ?? ''
+  const inviteToken   = extractInviteToken(redirectParam)
+
+  // Mode state machine — 'choose' by default unless arriving via invite link
+  const [mode, setMode] = useState<'choose' | 'create' | 'invite'>(
+    inviteToken ? 'invite' : 'choose'
+  )
+  const [inviteInput,      setInviteInput]      = useState('')
+  const [inviteValidating, setInviteValidating] = useState<'idle' | 'checking' | 'valid' | 'error'>('idle')
+  const [inviteError,      setInviteError]      = useState<string | null>(null)
+  const [resolvedToken,    setResolvedToken]    = useState<string | null>(inviteToken)
+  const [emailLocked,      setEmailLocked]      = useState(inviteToken !== null)
 
   const [companyName, setCompanyName] = useState('')
   const [userName,    setUserName]    = useState('')
-  const [email,       setEmail]       = useState('')
+  const [email,       setEmail]       = useState(emailParam)
   const [password,    setPassword]    = useState('')
   const [error,       setError]       = useState<string | null>(null)
   const [loading,     setLoading]     = useState(false)
+
+  async function handleInviteValidation() {
+    setInviteError(null)
+
+    const trimmed = inviteInput.trim()
+    if (!trimmed) {
+      setInviteError('Ange en inbjudningslänk eller kod.')
+      return
+    }
+
+    // Try to extract token from a URL, otherwise treat the whole string as token
+    let token = trimmed
+    try {
+      const url = new URL(trimmed)
+      const pathMatch = url.pathname.match(/^\/invite\/([a-zA-Z0-9]{1,40})$/)
+      if (pathMatch) {
+        token = pathMatch[1]
+      }
+    } catch {
+      // Not a URL — use raw input as token
+    }
+
+    // Validate format
+    if (!/^[a-zA-Z0-9]{1,40}$/.test(token)) {
+      setInviteError('Ogiltig format på inbjudningskod.')
+      return
+    }
+
+    setInviteValidating('checking')
+
+    try {
+      const snap = await getDoc(doc(db, 'invitations', token))
+      if (!snap.exists() || snap.data()?.status !== 'pending') {
+        setInviteValidating('error')
+        setInviteError('Länken är ogiltig, redan använd eller har löpt ut.')
+        return
+      }
+
+      const inviteEmail = snap.data()?.email as string | undefined
+      setResolvedToken(token)
+      if (inviteEmail) setEmail(inviteEmail)
+      setEmailLocked(true)
+      setInviteValidating('valid')
+      setInviteError(null)
+    } catch {
+      setInviteValidating('error')
+      setInviteError('Kunde inte kontrollera inbjudningskoden. Försök igen.')
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -28,9 +101,9 @@ export default function SignupForm() {
     const trimmedName    = userName.trim()
     const trimmedEmail   = email.trim()
 
-    if (!trimmedCompany) { setError('Company name is required.'); return }
-    if (!trimmedName)    { setError('Your name is required.'); return }
-    if (!trimmedEmail)   { setError('Email is required.'); return }
+    if (!(mode === 'invite') && !trimmedCompany) { setError('Company name is required.'); return }
+    if (!trimmedName)                             { setError('Your name is required.'); return }
+    if (!trimmedEmail)                            { setError('Email is required.'); return }
     if (password.length < MIN_PASSWORD_LENGTH) {
       setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
       return
@@ -58,17 +131,58 @@ export default function SignupForm() {
     }
 
     try {
+      await updateProfile(credential.user, { displayName: trimmedName })
+    } catch {/* best-effort — Firestore writes are the source of truth */}
+
+    try {
       await sendEmailVerification(credential.user)
     } catch {/* best-effort */}
 
-    // ── Step 2: Create company server-side (no CORS) ──────────────────────
-    // Pass the initial token only for identity verification. Claims are set
-    // inside setupNewCompany; we must refresh the token AFTER this call.
+    if (mode === 'invite') {
+      // ── Invite path: accept invitation (no new company) ──────────────────
+      // onUserCreate trigger also fires, but calling the callable gives us a
+      // synchronous result we can act on immediately and gives a clear error
+      // if the token is stale/mismatched before we create a session.
+      try {
+        const fns = getFunctions(auth.app, 'europe-west1')
+        const accept = httpsCallable(fns, 'acceptInvitationByToken')
+        await accept({ token: resolvedToken, name: trimmedName })
+      } catch (inviteErr) {
+        // Auth user was created but invite failed — clean up the orphan.
+        await credential.user.delete().catch(() => {/* best-effort */})
+
+        const msg = (inviteErr as { message?: string }).message ?? ''
+        if (msg.includes('different email')) {
+          setError('This invitation was sent to a different email address.')
+        } else if (msg.includes('already been used') || msg.includes('not found')) {
+          setError('This invitation link has already been used or is no longer valid.')
+        } else {
+          setError('Failed to accept the invitation. Please try again.')
+        }
+        setLoading(false)
+        return
+      }
+
+      // Force-refresh token so custom claims (activeCompanyId) take effect.
+      try {
+        const freshToken = await credential.user.getIdToken(/* forceRefresh */ true)
+        await createSession(freshToken)
+      } catch {
+        await credential.user.delete().catch(() => {/* best-effort */})
+        setError('Failed to create session. Please try signing in.')
+        setLoading(false)
+        return
+      }
+
+      router.push('/verify-email')
+      return
+    }
+
+    // ── Standard path: create company + session ────────────────────────────
     try {
       const idToken = await credential.user.getIdToken()
       await setupNewCompany(idToken, trimmedCompany, trimmedName)
     } catch (err) {
-      // Clean up the orphaned auth user so the user can retry.
       await credential.user.delete().catch(() => {/* best-effort */})
 
       const msg = err instanceof Error ? err.message : ''
@@ -81,7 +195,7 @@ export default function SignupForm() {
       return
     }
 
-    // ── Step 3: Force token refresh to pick up new claims, then create session
+    // Force token refresh to pick up new claims, then create session.
     try {
       const freshToken = await credential.user.getIdToken(/* forceRefresh */ true)
       await createSession(freshToken)
@@ -95,10 +209,119 @@ export default function SignupForm() {
     router.push('/verify-email')
   }
 
+  // ── Mode: choose ──────────────────────────────────────────────────────────
+  if (mode === 'choose') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>CREATE ACCOUNT</h1>
+
+          <div className={styles.modeCards}>
+            <button
+              className={styles.modeCard}
+              type="button"
+              onClick={() => setMode('create')}
+            >
+              Skapa ett nytt företag
+            </button>
+            <button
+              className={styles.modeCard}
+              type="button"
+              onClick={() => setMode('invite')}
+            >
+              Jag har en inbjudningslänk
+            </button>
+          </div>
+
+          <p className={styles.footer}>
+            Already have an account?{' '}
+            <Link href="/login">Sign in</Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Mode: invite — manual token input step (no URL token yet) ─────────────
+  if (mode === 'invite' && resolvedToken === null) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>CREATE ACCOUNT</h1>
+
+          <button
+            className={styles.backLink}
+            type="button"
+            onClick={() => { setMode('choose'); setInviteError(null); setInviteValidating('idle') }}
+          >
+            ← Tillbaka
+          </button>
+
+          <div className={styles.form}>
+            {inviteError && (
+              <div className={styles.error} role="alert" aria-live="assertive">
+                {inviteError}
+              </div>
+            )}
+
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="inviteInput">
+                Inbjudningslänk eller kod
+              </label>
+              <input
+                id="inviteInput"
+                className={styles.input}
+                type="text"
+                value={inviteInput}
+                onChange={(e) => setInviteInput(e.target.value)}
+                disabled={inviteValidating === 'checking'}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleInviteValidation() } }}
+              />
+            </div>
+
+            <button
+              className={styles.submitBtn}
+              type="button"
+              disabled={inviteValidating === 'checking'}
+              onClick={handleInviteValidation}
+            >
+              {inviteValidating === 'checking' ? 'Kontrollerar…' : 'Fortsätt'}
+            </button>
+          </div>
+
+          <p className={styles.footer}>
+            Already have an account?{' '}
+            <Link href="/login">Sign in</Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Mode: create OR invite with resolvedToken — show the full form ─────────
   return (
     <div className={styles.page}>
       <div className={styles.formCard}>
         <h1 className={styles.pageTitle}>CREATE ACCOUNT</h1>
+
+        <button
+          className={styles.backLink}
+          type="button"
+          onClick={() => {
+            if (mode === 'invite') {
+              // Go back to the token-input step (only for manually-entered tokens)
+              setResolvedToken(null)
+              setEmailLocked(false)
+              setEmail('')
+              setInviteValidating('idle')
+              setInviteError(null)
+            } else {
+              setMode('choose')
+            }
+          }}
+        >
+          ← Tillbaka
+        </button>
 
         <form className={styles.form} onSubmit={handleSubmit} noValidate>
           {error && (
@@ -107,20 +330,22 @@ export default function SignupForm() {
             </div>
           )}
 
-          <div className={styles.field}>
-            <label className={styles.label} htmlFor="companyName">Company name</label>
-            <input
-              id="companyName"
-              className={styles.input}
-              type="text"
-              autoComplete="organization"
-              maxLength={100}
-              value={companyName}
-              onChange={(e) => setCompanyName(e.target.value)}
-              required
-              disabled={loading}
-            />
-          </div>
+          {!(mode === 'invite') && (
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="companyName">Company name</label>
+              <input
+                id="companyName"
+                className={styles.input}
+                type="text"
+                autoComplete="organization"
+                maxLength={100}
+                value={companyName}
+                onChange={(e) => setCompanyName(e.target.value)}
+                required
+                disabled={loading}
+              />
+            </div>
+          )}
 
           <div className={styles.field}>
             <label className={styles.label} htmlFor="userName">Your name</label>
@@ -147,7 +372,8 @@ export default function SignupForm() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              disabled={loading}
+              disabled={loading || emailLocked}
+              title={emailLocked ? 'E-post från din inbjudan' : undefined}
             />
           </div>
 

--- a/functions/src/auth/acceptInvitation.ts
+++ b/functions/src/auth/acceptInvitation.ts
@@ -1,0 +1,164 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { logger } from 'firebase-functions/v2';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { MembershipDocument } from '../types';
+
+/**
+ * Callable function for already-authenticated users accepting an invite via link.
+ *
+ * @param data.token - The 20-char invite token from the invite URL
+ * @returns { success: true, companyId }
+ * @throws unauthenticated   if caller is not signed in
+ * @throws invalid-argument  if token is missing or malformed
+ * @throws not-found         if no matching pending invitation exists
+ * @throws already-exists    if caller is already a member of the company
+ */
+export const acceptInvitationByToken = onCall(
+  { region: 'europe-west1', cors: true, invoker: 'public' },
+  async (request) => {
+    // ── Auth guard ────────────────────────────────────────────────────────────
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Must be signed in.');
+    }
+
+    const uid = request.auth.uid;
+    const callerEmail = (request.auth.token.email ?? '').toLowerCase();
+
+    // ── Input validation ──────────────────────────────────────────────────────
+    const rawToken: unknown = request.data.token;
+    if (typeof rawToken !== 'string' || rawToken.trim().length === 0) {
+      throw new HttpsError('invalid-argument', 'token is required.');
+    }
+
+    const token = rawToken.trim();
+
+    const rawName: unknown = request.data.name;
+    const explicitName =
+      typeof rawName === 'string' && rawName.trim().length > 0
+        ? rawName.trim()
+        : undefined;
+    const db = getFirestore();
+
+    // ── Resolve mirror doc ────────────────────────────────────────────────────
+    const mirrorRef = db.collection('invitations').doc(token);
+    const mirrorSnap = await mirrorRef.get();
+
+    if (!mirrorSnap.exists) {
+      throw new HttpsError('not-found', 'Invitation not found or already used.');
+    }
+
+    const mirror = mirrorSnap.data()!;
+
+    if (mirror['status'] !== 'pending') {
+      throw new HttpsError('not-found', 'This invitation link has already been used or revoked.');
+    }
+
+    const companyId: string = mirror['companyId'];
+    const inviteId: string = mirror['inviteId'];
+    const inviteEmail: string = (mirror['email'] as string).toLowerCase();
+
+    // ── Email must match ──────────────────────────────────────────────────────
+    if (callerEmail !== inviteEmail) {
+      throw new HttpsError(
+        'permission-denied',
+        'This invitation was sent to a different email address.',
+      );
+    }
+
+    const inviteRef = db.doc(`companies/${companyId}/invitations/${inviteId}`);
+    const memberRef = db.doc(`companies/${companyId}/members/${uid}`);
+    const userMembershipRef = db.doc(`users/${uid}/memberships/${companyId}`);
+    const userRef = db.doc(`users/${uid}`);
+
+    const now = Timestamp.now();
+    const nowIso = now.toDate().toISOString();
+
+    // ── Resolve invite role ───────────────────────────────────────────────────
+    const inviteSnap = await inviteRef.get();
+    if (!inviteSnap.exists) {
+      throw new HttpsError('not-found', 'Invitation record not found.');
+    }
+
+    const inviteData = inviteSnap.data()!;
+    const role: MembershipDocument['role'] = inviteData['role'] ?? 'crew';
+    const displayName = explicitName ?? request.auth.token.name ?? callerEmail;
+
+    // ── Transaction ───────────────────────────────────────────────────────────
+    let txSucceeded = false;
+    try {
+      await db.runTransaction(async (tx) => {
+        const existingMember = await tx.get(memberRef);
+        if (existingMember.exists) {
+          throw new HttpsError('already-exists', 'You are already a member of this company.');
+        }
+
+        // 1. Create member under company
+        tx.set(memberRef, {
+          uid,
+          name: displayName,
+          email: callerEmail,
+          role,
+          joinedAt: now,
+          companyId,
+        });
+
+        // 2. Create membership under user
+        const membership: MembershipDocument = {
+          companyId,
+          role,
+          joinedAt: now,
+        };
+        tx.set(userMembershipRef, membership);
+
+        // 3. Mark invitation accepted
+        tx.update(inviteRef, {
+          status: 'accepted',
+          acceptedAt: nowIso,
+          acceptedBy: uid,
+        });
+
+        // 4. Mark mirror accepted
+        tx.update(mirrorRef, { status: 'accepted' });
+      });
+      txSucceeded = true;
+    } catch (err) {
+      if (err instanceof HttpsError && err.code === 'already-exists') {
+        // onUserCreate beat us to creating the member doc — that is fine.
+        // We still need to write users/{uid} name+email below.
+        logger.info('acceptInvitationByToken: onUserCreate already created member doc', {
+          uid: uid.slice(0, 8) + '...',
+          companyId,
+        });
+      } else {
+        throw err;
+      }
+    }
+
+    // Always write name + email to user root doc — runs regardless of which
+    // path won the race (callable tx or onUserCreate trigger).
+    await userRef.set({ name: displayName, email: callerEmail }, { merge: true });
+
+    // ── Set custom claims if none exist (only when we ran the full tx) ────────
+    // If onUserCreate won the race, it already set claims — skip to avoid churn.
+    if (txSucceeded) {
+      const existingClaims = (request.auth.token ?? {}) as Record<string, unknown>;
+      if (!existingClaims['activeCompanyId']) {
+        await getAuth().setCustomUserClaims(uid, {
+          activeCompanyId: companyId,
+          role,
+        });
+
+        await userRef.set({ activeCompanyId: companyId }, { merge: true });
+      }
+    }
+
+    logger.info('acceptInvitationByToken: accepted', {
+      uid: uid.slice(0, 8) + '...',
+      companyId,
+      inviteId,
+    });
+
+    return { success: true, companyId };
+  },
+);

--- a/functions/src/auth/onUserCreate.ts
+++ b/functions/src/auth/onUserCreate.ts
@@ -1,0 +1,145 @@
+import * as functions from 'firebase-functions/v1';
+import { logger } from 'firebase-functions/v2';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { MembershipDocument } from '../types';
+
+/**
+ * Triggered when a new Firebase Auth user is created.
+ * Scans the invitations collection-group for pending invitations matching
+ * the new user's email, and for each match:
+ *   1. Creates companies/{cid}/members/{uid}
+ *   2. Creates users/{uid}/memberships/{cid}
+ *   3. Writes name + email to users/{uid}
+ *   4. Marks the invitation accepted (both subcollection + mirror)
+ *   5. Sets custom claims if user has no activeCompanyId yet
+ *
+ * Runs in europe-west1 (inherited from setGlobalOptions in index.ts).
+ */
+export const onUserCreate = functions
+  .region('europe-west1')
+  .auth.user()
+  .onCreate(async (user) => {
+  if (!user.email) {
+    logger.info('onUserCreate: no email, skipping', { uid: user.uid.slice(0, 8) + '...' });
+    return;
+  }
+
+  const email = user.email.toLowerCase();
+  const uid = user.uid;
+  const db = getFirestore();
+
+  // Find all pending invitations for this email across all companies
+  const invitationsSnap = await db
+    .collectionGroup('invitations')
+    .where('email', '==', email)
+    .where('status', '==', 'pending')
+    .get();
+
+  if (invitationsSnap.empty) {
+    logger.info('onUserCreate: no pending invitations', { uid: uid.slice(0, 8) + '...' });
+    return;
+  }
+
+  logger.info('onUserCreate: found pending invitations', {
+    uid: uid.slice(0, 8) + '...',
+    count: invitationsSnap.size,
+  });
+
+  // Resolve user's display name from Auth record
+  const displayName = user.displayName ?? email;
+
+  // Process each invitation — use transactions to avoid partial writes
+  for (const inviteDoc of invitationsSnap.docs) {
+    const inviteData = inviteDoc.data();
+    const companyId: string = inviteData.companyId;
+    const token: string = inviteData.token;
+    const role: MembershipDocument['role'] = inviteData.role ?? 'crew';
+    const now = Timestamp.now();
+    const nowIso = now.toDate().toISOString();
+
+    const memberRef = db.doc(`companies/${companyId}/members/${uid}`);
+    const mirrorRef = db.collection('invitations').doc(token);
+    const userMembershipRef = db.doc(`users/${uid}/memberships/${companyId}`);
+    const userRef = db.doc(`users/${uid}`);
+
+    try {
+      await db.runTransaction(async (tx) => {
+        // Guard: don't create duplicate member
+        const existingMember = await tx.get(memberRef);
+        if (existingMember.exists) {
+          logger.warn('onUserCreate: member already exists, skipping', {
+            uid: uid.slice(0, 8) + '...',
+            companyId,
+          });
+          return;
+        }
+
+        // 1. Create member doc under company
+        tx.set(memberRef, {
+          uid,
+          name: displayName,
+          email,
+          role,
+          joinedAt: now,
+          companyId,
+        });
+
+        // 2. Create membership doc under user (for collectionGroup GDPR queries)
+        const membership: MembershipDocument = {
+          companyId,
+          role,
+          joinedAt: now,
+        };
+        tx.set(userMembershipRef, membership);
+
+        // 3. Write name + email to user root doc so account page can read it
+        tx.set(userRef, { name: displayName, email }, { merge: true });
+
+        // 4. Mark invitation accepted in subcollection
+        tx.update(inviteDoc.ref, {
+          status: 'accepted',
+          acceptedAt: nowIso,
+          acceptedBy: uid,
+        });
+
+        // 5. Mark mirror accepted
+        tx.update(mirrorRef, { status: 'accepted' });
+      });
+
+      // 5. Set custom claims if user has no activeCompanyId yet
+      const existingClaims = (user.customClaims ?? {}) as Record<string, unknown>;
+      if (!existingClaims['activeCompanyId']) {
+        await getAuth().setCustomUserClaims(uid, {
+          activeCompanyId: companyId,
+          role,
+        });
+
+        // Sync user document
+        await userRef.set(
+          { activeCompanyId: companyId },
+          { merge: true },
+        );
+
+        logger.info('onUserCreate: set active claim', {
+          uid: uid.slice(0, 8) + '...',
+          companyId,
+          role,
+        });
+      }
+
+      logger.info('onUserCreate: invitation accepted', {
+        uid: uid.slice(0, 8) + '...',
+        companyId,
+        inviteId: inviteDoc.id,
+      });
+    } catch (err) {
+      logger.error('onUserCreate: transaction failed', {
+        uid: uid.slice(0, 8) + '...',
+        companyId,
+        inviteId: inviteDoc.id,
+        error: err,
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- **SignupForm**: Updated `updateProfile` to set the invited user's name during signup
- **acceptInvitation**: Moved `userRef.set(userData)` out of the transaction to ensure persisted name is written to Firestore
- **onUserCreate**: Added name field write to `users/{uid}.name` if present in user data

User has manually tested and verified the fix works correctly.