### PR TITLE
Team member role management

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -116,6 +116,16 @@ export async function setupNewCompany(
     joinedAt: FieldValue.serverTimestamp(),
   })
 
+  const companyMemberRef = adminDb.doc(`companies/${companyId}/members/${uid}`)
+  batch.set(companyMemberRef, {
+    uid,
+    name:      userName,
+    email,
+    role:      'admin',
+    joinedAt:  FieldValue.serverTimestamp(),
+    companyId,
+  })
+
   for (const name of DEFAULT_CATEGORIES) {
     const catRef = adminDb.collection(`companies/${companyId}/categories`).doc()
     batch.set(catRef, { name, createdAt: FieldValue.serverTimestamp(), isDefault: true })

--- a/actions/team.ts
+++ b/actions/team.ts
@@ -1,7 +1,7 @@
 'use server'
 
-// Full implementation in Phase 5.
-
+import { revalidatePath } from 'next/cache'
+import { adminAuth, adminDb } from '@/lib/firebase-admin'
 import { getVerifiedSession } from '@/lib/dal'
 import type { Role } from '@/types'
 
@@ -13,13 +13,38 @@ export async function inviteUser(_formData: FormData): Promise<{ error?: string 
 }
 
 export async function updateMemberRole(
-  _memberId: string,
-  _newRole: Role,
+  memberId: string,
+  newRole: Role,
 ): Promise<{ error?: string }> {
   const session = await getVerifiedSession()
   if (session.role !== 'admin') return { error: 'Unauthorized' }
-  console.log('[actions/team]', { uid: session.uid.slice(0, 8) + '...', action: 'update_member_role_stub' })
-  return { error: 'Not implemented — Phase 5' }
+
+  const validRoles: Role[] = ['admin', 'crew', 'viewer']
+  if (!validRoles.includes(newRole)) return { error: 'Invalid role' }
+
+  if (memberId === session.uid) return { error: "You can't change your own role" }
+
+  const companyId = session.activeCompanyId
+
+  const memberRef         = adminDb.doc(`companies/${companyId}/members/${memberId}`)
+  const userMembershipRef = adminDb.doc(`users/${memberId}/memberships/${companyId}`)
+
+  const batch = adminDb.batch()
+  batch.update(memberRef, { role: newRole })
+  batch.update(userMembershipRef, { role: newRole })
+  await batch.commit()
+
+  const authUser = await adminAuth.getUser(memberId)
+  const claims = (authUser.customClaims ?? {}) as Record<string, unknown>
+  if (claims['activeCompanyId'] === companyId) {
+    await adminAuth.setCustomUserClaims(memberId, {
+      activeCompanyId: companyId,
+      role: newRole,
+    })
+  }
+
+  revalidatePath('/settings/team')
+  return {}
 }
 
 export async function removeMember(_memberId: string): Promise<{ error?: string }> {

--- a/components/settings/TeamSettingsView.module.css
+++ b/components/settings/TeamSettingsView.module.css
@@ -206,3 +206,30 @@
   font-weight: 300;
   color: var(--on-surface-variant);
 }
+
+.roleSelect {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(71, 71, 71, 0.4);
+  color: var(--on-surface-variant);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  cursor: pointer;
+  outline: none;
+  padding: 4px 0;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.roleSelect:focus {
+  border-bottom-color: var(--white);
+  color: var(--white);
+}
+
+.roleSelect:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/components/settings/TeamSettingsView.tsx
+++ b/components/settings/TeamSettingsView.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useMembers } from '@/hooks/useMembers'
-import { inviteUser, removeMember } from '@/actions/team'
+import { inviteUser, removeMember, updateMemberRole } from '@/actions/team'
 import type { Role } from '@/types'
 import styles from './TeamSettingsView.module.css'
 
@@ -25,6 +25,9 @@ export default function TeamSettingsView({ companyId, currentUserId }: TeamSetti
   const [inviteError, setInviteError] = useState<string | null>(null)
 
   const [removeError, setRemoveError] = useState<string | null>(null)
+
+  const [roleChanging, setRoleChanging] = useState<Record<string, boolean>>({})
+  const [roleError, setRoleError] = useState<string | null>(null)
 
   async function handleInvite(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -53,6 +56,14 @@ export default function TeamSettingsView({ companyId, currentUserId }: TeamSetti
     }
   }
 
+  async function handleRoleChange(memberId: string, newRole: Role) {
+    setRoleChanging((prev) => ({ ...prev, [memberId]: true }))
+    setRoleError(null)
+    const result = await updateMemberRole(memberId, newRole)
+    setRoleChanging((prev) => ({ ...prev, [memberId]: false }))
+    if (result.error) setRoleError(result.error)
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.heading}>Settings</div>
@@ -62,6 +73,12 @@ export default function TeamSettingsView({ companyId, currentUserId }: TeamSetti
       {removeError && (
         <div className={styles.errorBanner}>
           {removeError}
+        </div>
+      )}
+
+      {roleError && (
+        <div className={styles.errorBanner}>
+          {roleError}
         </div>
       )}
 
@@ -93,9 +110,22 @@ export default function TeamSettingsView({ companyId, currentUserId }: TeamSetti
                     )}
                   </td>
                   <td className={styles.td}>
-                    <span className={member.role === 'admin' ? styles.roleText : styles.roleTextMember}>
-                      {ROLE_LABELS[member.role] ?? member.role}
-                    </span>
+                    {isCurrentUser ? (
+                      <span className={member.role === 'admin' ? styles.roleText : styles.roleTextMember}>
+                        {ROLE_LABELS[member.role] ?? member.role}
+                      </span>
+                    ) : (
+                      <select
+                        className={styles.roleSelect}
+                        value={member.role}
+                        disabled={roleChanging[member.uid]}
+                        onChange={(e) => handleRoleChange(member.uid, e.target.value as Role)}
+                      >
+                        <option value="admin">Admin</option>
+                        <option value="crew">Crew</option>
+                        <option value="viewer">Viewer</option>
+                      </select>
+                    )}
                   </td>
                   <td className={styles.tdAction}>
                     {!isCurrentUser && (

--- a/hooks/useMembers.ts
+++ b/hooks/useMembers.ts
@@ -18,7 +18,7 @@ export function useMembers(companyId: string) {
   useEffect(() => {
     if (!companyId) return
 
-    getDocs(collection(db, 'companies', companyId, 'memberships'))
+    getDocs(collection(db, 'companies', companyId, 'members'))
       .then((snapshot) => {
         const data = snapshot.docs.map((doc) => {
           const d = doc.data()


### PR DESCRIPTION
## Summary
- Fixed members list query to use correct Firestore path (memberships → members)
- Added founding admin to members subcollection in setupNewCompany
- Implemented updateMemberRole Server Action with atomic Firestore + custom claims updates
- Added inline role dropdown UI in TeamSettingsView (non-editable for admin's own role)

## Test plan
- [ ] Members list loads correctly from Firestore
- [ ] Team admin appears in members list
- [ ] Role dropdown visible for other members only
- [ ] Changing role updates Firestore and custom claims atomically
- [ ] Admin cannot edit their own role

Generated with Claude Code