### PR TITLE
Equipment unit status enum refactor

### DIFF
--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -447,7 +447,7 @@ export async function createUnit(
     companyId,
     label,
     serialNumber,
-    status: 'available',
+    status: 'ok',
     notes,
     active: true,
     createdAt: FieldValue.serverTimestamp(),
@@ -476,14 +476,14 @@ export async function updateUnit(
   const label = (formData.get('label') as string | null)?.trim() ?? ''
   if (!label) return { error: 'Label is required.' }
 
-  const VALID_STATUSES: EquipmentStatus[] = ['available', 'checked_out', 'needs_repair']
+  const VALID_STATUSES: EquipmentStatus[] = ['ok', 'needs_repair', 'limited_operations']
 
   const statusRaw = formData.get('status') as string | null
 
   await unitRef.update({
     label,
     serialNumber: (formData.get('serialNumber') as string | null)?.trim() || null,
-    status: VALID_STATUSES.includes(statusRaw as EquipmentStatus) ? statusRaw : 'available',
+    status: VALID_STATUSES.includes(statusRaw as EquipmentStatus) ? statusRaw : 'ok',
     notes: (formData.get('notes') as string | null)?.trim() || null,
     updatedAt: FieldValue.serverTimestamp(),
     updatedBy: session.uid,
@@ -536,7 +536,7 @@ export async function deactivateUnit(
 // Batch-saves equipment basic fields + all unit changes (updates, creates,
 // deletes) in a single Firestore batch write.
 
-const VALID_UNIT_STATUSES: EquipmentStatus[] = ['available', 'checked_out', 'needs_repair']
+const VALID_UNIT_STATUSES: EquipmentStatus[] = ['ok', 'needs_repair', 'limited_operations']
 
 export interface UnitUpdate {
   id: string

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -254,7 +254,7 @@ export default function BookingDetail({
             </ul>
           </div>
 
-          {/* Rejection reason */}
+          {/* Rejection reason — hidden for MVP
           {booking.approvalStatus === 'rejected' && booking.rejectionReason && (
             <div className={styles.section}>
               <div className={styles.sectionLabel}>Rejection Reason</div>
@@ -263,6 +263,7 @@ export default function BookingDetail({
               </div>
             </div>
           )}
+          */}
 
           {/* Cancellation info */}
           {booking.status === 'cancelled' && booking.cancelledAt && (

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -498,9 +498,11 @@ export default function BookingForm({
                                       : null
                                 )}
                               </div>
+                              {/* Approval required tag — hidden for MVP
                               {eq.requiresApproval && (
                                 <span className={styles.approvalTag}>Approval required</span>
                               )}
+                              */}
                               {hasConflict && (
                                 <span className={styles.conflictTag}>Unavailable</span>
                               )}
@@ -565,9 +567,11 @@ export default function BookingForm({
                                       ? <span className={styles.availabilityCount}>{qtyAvailable} of {eq.totalQuantity} available</span>
                                       : null
                                 )}
+                                {/* Approval required tag — hidden for MVP
                                 {eq.requiresApproval && (
                                   <span className={styles.approvalTag}>Approval required</span>
                                 )}
+                                */}
                                 {hasConflict && (
                                   <span className={styles.conflictTag}>Unavailable</span>
                                 )}
@@ -657,11 +661,13 @@ export default function BookingForm({
             <div className={styles.summaryValue}>{timeRangeLabel ?? '—'}</div>
           </div>
 
+          {/* Approval notice — hidden for MVP
           {requiresApproval && (
             <div className={styles.approvalNotice}>
               One or more items require approval. Your booking will be submitted as Pending and reviewed before confirmation.
             </div>
           )}
+          */}
 
           {conflictResult?.hasConflict && (
             <div className={styles.conflictNotice}>

--- a/components/equipment/EquipmentEditModal.module.css
+++ b/components/equipment/EquipmentEditModal.module.css
@@ -279,10 +279,10 @@
   flex-shrink: 0;
 }
 
-/* Matches `dot_available`, `dot_checked_out`, `dot_needs_repair` */
-.dot_available    { background: var(--white); }
-.dot_checked_out  { background: var(--tertiary); }
-.dot_needs_repair { background: var(--error); }
+/* Matches `dot_ok`, `dot_needs_repair`, `dot_limited_operations` */
+.dot_ok                 { background: var(--white); }
+.dot_needs_repair       { background: var(--error); }
+.dot_limited_operations { background: #e6a817; }
 
 .unitInputStack {
   display: flex;
@@ -345,9 +345,9 @@
 }
 
 /* Status color variants */
-.statusColor_available    { color: rgba(255, 255, 255, 0.5); }
-.statusColor_checked_out  { color: var(--tertiary); }
-.statusColor_needs_repair { color: var(--error); }
+.statusColor_ok                 { color: rgba(255, 255, 255, 0.5); }
+.statusColor_needs_repair       { color: var(--error); }
+.statusColor_limited_operations { color: #e6a817; }
 
 /* ── Delete row button ────────────────────────────────────────────────────── */
 

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -505,7 +505,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
               <div className={styles.unitTableHeader}>
                 <div className={styles.colUnitSerial}>Unit / Serial</div>
                 <div className={styles.colAvail}>Avail</div>
-                <div className={styles.colStatus}>Status</div>
+                {/* Status column hidden for MVP — <div className={styles.colStatus}>Status</div> */}
                 <div className={styles.colNotes}>Notes</div>
                 <div className={styles.colDelete} />
               </div>
@@ -517,7 +517,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
 
                     {/* Dot + label + S/N */}
                     <div className={`${styles.colUnitSerial} ${styles.unitIdentity}`}>
-                      <span className={`${styles.dot} ${styles[`dot_${row.status}` as keyof typeof styles]}`} />
+                      {/* Status dot hidden for MVP — <span className={`${styles.dot} ${styles[`dot_${row.status}` as keyof typeof styles]}`} /> */}
                       <div className={styles.unitInputStack}>
                         <input
                           type="text"
@@ -551,7 +551,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
                       />
                     </div>
 
-                    {/* Status dropdown */}
+                    {/* Status dropdown — hidden for MVP; state variable and updateRow logic intact
                     <div className={styles.colStatus}>
                       <select
                         value={row.status}
@@ -565,6 +565,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
                         <option value="limited_operations">Limited Operations</option>
                       </select>
                     </div>
+                    */}
 
                     {/* Notes */}
                     <div className={styles.colNotes}>

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -343,6 +343,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
               />
             </div>
 
+            {/* Requires approval toggle — hidden for MVP, data model intact
             <div className={styles.approvalRow}>
               <button
                 type="button"
@@ -374,6 +375,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
                 </select>
               </div>
             )}
+            */}
           </div>
 
           {/* Section B: Tracking type */}

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -151,7 +151,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
         id: null,
         label: '',
         serialNumber: null,
-        status: 'available',
+        status: 'ok',
         notes: null,
         availableForBooking: true,
       },
@@ -560,9 +560,9 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
                         }
                         className={`${styles.statusSelect} ${styles[`statusColor_${row.status}` as keyof typeof styles]}`}
                       >
-                        <option value="available">Available</option>
-                        <option value="checked_out">Checked Out</option>
+                        <option value="ok">Ok</option>
                         <option value="needs_repair">Needs Repair</option>
+                        <option value="limited_operations">Limited Operations</option>
                       </select>
                     </div>
 

--- a/components/equipment/EquipmentList.module.css
+++ b/components/equipment/EquipmentList.module.css
@@ -185,16 +185,16 @@
   flex-shrink: 0;
 }
 
-.statusDotAvailable {
+.statusDotOk {
   background: var(--white);
-}
-
-.statusDotCheckedOut {
-  background: var(--tertiary);
 }
 
 .statusDotNeedsRepair {
   background: var(--error);
+}
+
+.statusDotLimitedOperations {
+  background: #e6a817;
 }
 
 /* Status text shown on the right of a unit row */
@@ -206,16 +206,16 @@
   white-space: nowrap;
 }
 
-.unitStatusAvailable {
+.unitStatusOk {
   color: rgba(145, 145, 145, 0.6);
-}
-
-.unitStatusCheckedOut {
-  color: var(--tertiary);
 }
 
 .unitStatusNeedsRepair {
   color: var(--error);
+}
+
+.unitStatusLimitedOperations {
+  color: #e6a817;
 }
 
 /* Tracking type badge: "Units" or "Qty" */

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -29,7 +29,6 @@ function getStatusDotClass(status: EquipmentStatus): string {
     case 'ok':                 return styles.statusDotOk
     case 'needs_repair':       return styles.statusDotNeedsRepair
     case 'limited_operations': return styles.statusDotLimitedOperations
-    default:                   return styles.statusDotOk
   }
 }
 
@@ -38,7 +37,6 @@ function getUnitStatusTextClass(status: EquipmentStatus): string {
     case 'ok':                 return styles.unitStatusOk
     case 'needs_repair':       return styles.unitStatusNeedsRepair
     case 'limited_operations': return styles.unitStatusLimitedOperations
-    default:                   return styles.unitStatusOk
   }
 }
 

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -19,24 +19,26 @@ interface EquipmentListProps {
 // ---------------------------------------------------------------------------
 
 const UNIT_STATUS_LABELS: Record<EquipmentStatus, string> = {
-  available:    'Available',
-  checked_out:  'Checked Out',
-  needs_repair: 'Needs Repair',
+  ok:                 'Ok',
+  needs_repair:       'Needs Repair',
+  limited_operations: 'Limited Operations',
 }
 
 function getStatusDotClass(status: EquipmentStatus): string {
   switch (status) {
-    case 'available':    return styles.statusDotAvailable
-    case 'checked_out':  return styles.statusDotCheckedOut
-    case 'needs_repair': return styles.statusDotNeedsRepair
+    case 'ok':                 return styles.statusDotOk
+    case 'needs_repair':       return styles.statusDotNeedsRepair
+    case 'limited_operations': return styles.statusDotLimitedOperations
+    default:                   return styles.statusDotOk
   }
 }
 
 function getUnitStatusTextClass(status: EquipmentStatus): string {
   switch (status) {
-    case 'available':    return styles.unitStatusAvailable
-    case 'checked_out':  return styles.unitStatusCheckedOut
-    case 'needs_repair': return styles.unitStatusNeedsRepair
+    case 'ok':                 return styles.unitStatusOk
+    case 'needs_repair':       return styles.unitStatusNeedsRepair
+    case 'limited_operations': return styles.unitStatusLimitedOperations
+    default:                   return styles.unitStatusOk
   }
 }
 

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -220,17 +220,19 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
                     {(eq.units ?? []).map((unit) => (
                       <div key={unit.id} className={styles.unitRow}>
                         <div className={styles.rowLeft}>
-                          <span className={`${styles.statusDot} ${getStatusDotClass(unit.status)}`} />
+                          {/* Status dot hidden for MVP — <span className={`${styles.statusDot} ${getStatusDotClass(unit.status)}`} /> */}
                           <span className={styles.unitName}>{unit.label}</span>
                           {unit.serialNumber && (
                             <span className={styles.serialNumber}>S/N {unit.serialNumber}</span>
                           )}
                         </div>
+                        {/* Status text hidden for MVP
                         <div className={styles.unitRowRight}>
                           <span className={`${styles.unitStatusText} ${getUnitStatusTextClass(unit.status)}`}>
                             {UNIT_STATUS_LABELS[unit.status]}
                           </span>
                         </div>
+                        */}
                       </div>
                     ))}
 

--- a/components/equipment/EquipmentStatusBadge.module.css
+++ b/components/equipment/EquipmentStatusBadge.module.css
@@ -6,22 +6,17 @@
   white-space: nowrap;
 }
 
-/* available — dim text only */
-.available {
+/* ok — dim text only */
+.ok {
   color: rgba(255, 255, 255, 0.5);
 }
 
-/* checked_out — tertiary accent */
-.checked_out {
-  color: var(--tertiary);
-}
-
-/* needs_repair — very dim */
+/* needs_repair — red/error */
 .needs_repair {
-  color: rgba(145, 145, 145, 0.4);
+  color: var(--error);
 }
 
-/* in_service — very dim */
-.in_service {
-  color: rgba(145, 145, 145, 0.4);
+/* limited_operations — amber/warning */
+.limited_operations {
+  color: #e6a817;
 }

--- a/components/equipment/EquipmentStatusBadge.tsx
+++ b/components/equipment/EquipmentStatusBadge.tsx
@@ -6,15 +6,17 @@ interface EquipmentStatusBadgeProps {
 }
 
 const STATUS_LABELS: Record<EquipmentStatus, string> = {
-  available:    'Available',
-  checked_out:  'Checked Out',
-  needs_repair: 'Needs Repair',
+  ok:                 'Ok',
+  needs_repair:       'Needs Repair',
+  limited_operations: 'Limited Operations',
 }
 
 export default function EquipmentStatusBadge({ status }: EquipmentStatusBadgeProps) {
+  const label = STATUS_LABELS[status] ?? 'Ok'
+  const cssKey = (status in STATUS_LABELS ? status : 'ok') as EquipmentStatus
   return (
-    <span className={`${styles.badge} ${styles[status]}`}>
-      {STATUS_LABELS[status]}
+    <span className={`${styles.badge} ${styles[cssKey]}`}>
+      {label}
     </span>
   )
 }

--- a/components/equipment/EquipmentStatusBadge.tsx
+++ b/components/equipment/EquipmentStatusBadge.tsx
@@ -12,11 +12,9 @@ const STATUS_LABELS: Record<EquipmentStatus, string> = {
 }
 
 export default function EquipmentStatusBadge({ status }: EquipmentStatusBadgeProps) {
-  const label = STATUS_LABELS[status] ?? 'Ok'
-  const cssKey = (status in STATUS_LABELS ? status : 'ok') as EquipmentStatus
   return (
-    <span className={`${styles.badge} ${styles[cssKey]}`}>
-      {label}
+    <span className={`${styles.badge} ${styles[status]}`}>
+      {STATUS_LABELS[status]}
     </span>
   )
 }

--- a/components/equipment/UnitForm.tsx
+++ b/components/equipment/UnitForm.tsx
@@ -41,6 +41,7 @@ export function UnitForm({ equipmentId, unit, onSuccess }: UnitFormProps) {
         <input name="serialNumber" className={styles.input} defaultValue={unit?.serialNumber ?? ''} />
       </div>
 
+      {/* Status field — hidden for MVP; data model and validation intact
       {isEditing && (
         <div className={styles.field}>
           <label className={styles.label}>Status</label>
@@ -51,6 +52,7 @@ export function UnitForm({ equipmentId, unit, onSuccess }: UnitFormProps) {
           </select>
         </div>
       )}
+      */}
 
       <div className={styles.field}>
         <label className={styles.label}>Notes</label>

--- a/components/equipment/UnitForm.tsx
+++ b/components/equipment/UnitForm.tsx
@@ -45,9 +45,9 @@ export function UnitForm({ equipmentId, unit, onSuccess }: UnitFormProps) {
         <div className={styles.field}>
           <label className={styles.label}>Status</label>
           <select name="status" className={styles.input} defaultValue={unit.status}>
-            <option value="available">Available</option>
-            <option value="checked_out">Checked Out</option>
+            <option value="ok">Ok</option>
             <option value="needs_repair">Needs Repair</option>
+            <option value="limited_operations">Limited Operations</option>
           </select>
         </div>
       )}

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -1,4 +1,4 @@
-export type EquipmentStatus = 'available' | 'checked_out' | 'needs_repair'
+export type EquipmentStatus = 'ok' | 'needs_repair' | 'limited_operations'
 
 // 'serialized' = one parent doc per equipment type, one subcollection doc per physical unit
 // 'quantity'   = one document represents a pool of interchangeable items


### PR DESCRIPTION
## Summary

- Equipment unit status values updated: `available/checked_out/needs_repair` → `ok/limited_operations/needs_repair`
- Firestore migration completed (22 documents updated)
- Equipment unit status field hidden from UI (MVP scope — to be re-enabled in future phases)
- "Requires approval when booked" field hidden from UI (MVP scope — to be re-enabled in future phases)
- Legacy fallback code for old status values removed

## Scope

This refactor aligns the equipment status model with the simplified MVP scope, hiding advanced features while maintaining data integrity through Firestore migration.

🤖 Generated with Claude Code