### PR TITLE
Fix TypeScript error in bookings page filter

### DIFF
--- a/app/(app)/(bookings-views)/bookings/list/page.tsx
+++ b/app/(app)/(bookings-views)/bookings/list/page.tsx
@@ -9,7 +9,7 @@ export default async function BookingsListPage() {
   const initialBookings = await getBookings(session.activeCompanyId)
 
   // Fetch UserProfile for each unique userId in the bookings
-  const uniqueUserIds = Array.from(new Set(initialBookings.map(b => b.userId).filter(Boolean)))
+  const uniqueUserIds = Array.from(new Set(initialBookings.map(b => b.userId).filter((id): id is string => id !== null && id !== undefined)))
   const userProfilesArray = await Promise.all(
     uniqueUserIds.map(uid => getUserProfile(uid)),
   )


### PR DESCRIPTION
## Summary
- Replaces `.filter(Boolean)` with a type-predicate filter to properly narrow `string | null` to `string[]`
- Resolves TypeScript build error: "Argument of type 'string | null' is not assignable to parameter of type 'string'"
- Unblocks App Hosting build

## Test plan
- Verify build completes without TypeScript errors
- Confirm bookings list page loads and displays user profiles correctly