### PR TITLE
fix: remove unused role prop from MobileBottomNav

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,7 +29,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       <main className={styles.main}>
         {children}
       </main>
-      <MobileBottomNav role={session.role} />
+      <MobileBottomNav />
     </div>
   )
 }

--- a/components/nav/MobileBottomNav.tsx
+++ b/components/nav/MobileBottomNav.tsx
@@ -3,11 +3,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import styles from './MobileBottomNav.module.css'
 
-interface MobileBottomNavProps {
-  role: 'admin' | 'member' | 'viewer'
-}
-
-export function MobileBottomNav({ role }: MobileBottomNavProps) {
+export function MobileBottomNav() {
   const pathname = usePathname()
   const isActive = (path: string) => pathname.startsWith(path)
   return (


### PR DESCRIPTION
## Summary
Remove unused `role` prop from `MobileBottomNav` component to unblock App Hosting build.

- Previous App Hosting build failed with TS error: `Type 'Role' is not assignable to type '"admin" | "viewer" | "member"'`
- The prop was dead code (declared but never used in component body)
- Removing the prop everywhere is the cleanest fix and resolves the type conflict

## Test plan
- Build passes with no TS errors
- MobileBottomNav renders correctly without role prop