### PR TITLE
fix(tsconfig): exclude functions/ from Next.js typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "functions"]
 }


### PR DESCRIPTION
Cloud Functions has its own tsconfig and dependencies. Next.js should not typecheck functions/ code, which was causing build failures on App Hosting deploys when functions/node_modules was not installed.