### PR TITLE
Merge dev: exclude functions from Next.js typecheck

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "functions"]
 }


### PR DESCRIPTION
Merging dev to main with the tsconfig fix that excludes functions/ from Next.js typecheck.

This fixes build failures on App Hosting deploys where Next.js was attempting to typecheck Cloud Functions code (which has its own tsconfig and dependencies).