### PR TITLE
Merge dev: lazy firebase-admin init for App Hosting build

### DIFF
--- a/lib/firebase-admin.ts
+++ b/lib/firebase-admin.ts
@@ -4,7 +4,7 @@ import { initializeApp, getApps, cert, App } from 'firebase-admin/app'
 import { getAuth, Auth } from 'firebase-admin/auth'
 import { getFirestore, Firestore } from 'firebase-admin/firestore'
 
-function createAdminApp(): App {
+function getAdminApp(): App {
   if (getApps().length > 0) {
     return getApps()[0]
   }
@@ -22,7 +22,23 @@ function createAdminApp(): App {
   })
 }
 
-const adminApp = createAdminApp()
+// Lazy proxies so importing this module never triggers initialization.
+// The service account env var is RUNTIME-only; eager init would throw during
+// Next.js build's "Collecting page data" phase.
+function lazy<T extends object>(factory: () => T): T {
+  let instance: T | undefined
+  const resolve = (): T => {
+    if (!instance) instance = factory()
+    return instance
+  }
+  return new Proxy({} as T, {
+    get(_target, prop, receiver) {
+      const target = resolve()
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
+}
 
-export const adminAuth: Auth      = getAuth(adminApp)
-export const adminDb:   Firestore = getFirestore(adminApp)
+export const adminAuth: Auth = lazy(() => getAuth(getAdminApp()))
+export const adminDb: Firestore = lazy(() => getFirestore(getAdminApp()))


### PR DESCRIPTION
Merges lazy Firebase Admin initialization fix (PR #151) to main. App Hosting build was failing due to eager initialization at module load time when the service account secret is runtime-only. Lazy Proxy-based initialization defers SDK setup until first method call.