### PR TITLE
fix(stripe): defer initialization with lazy Proxy

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -2,12 +2,31 @@ import 'server-only'
 
 import Stripe from 'stripe'
 
-const stripeSecretKey = process.env.STRIPE_SECRET_KEY
-if (!stripeSecretKey) {
-  throw new Error('[stripe] STRIPE_SECRET_KEY is not set')
+// Lazy proxy so importing this module never instantiates the Stripe SDK.
+// The secret is RUNTIME-only; eager init would throw during Next.js build's
+// "Collecting page data" phase (e.g. /api/webhooks/stripe).
+function lazy<T extends object>(factory: () => T): T {
+  let instance: T | undefined
+  const resolve = (): T => {
+    if (!instance) instance = factory()
+    return instance
+  }
+  return new Proxy({} as T, {
+    get(_target, prop, receiver) {
+      const target = resolve()
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  })
 }
 
-export const stripe = new Stripe(stripeSecretKey, {
-  apiVersion: '2026-02-25.clover',
-  typescript: true,
+export const stripe: Stripe = lazy(() => {
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY
+  if (!stripeSecretKey) {
+    throw new Error('[stripe] STRIPE_SECRET_KEY is not set')
+  }
+  return new Stripe(stripeSecretKey, {
+    apiVersion: '2026-02-25.clover',
+    typescript: true,
+  })
 })


### PR DESCRIPTION
Resolves build failures during App Hosting "Collecting page data" phase.

STRIPE_SECRET_KEY is only available at runtime, but Next.js evaluates route modules at build time. This implements the same lazy Proxy pattern applied to firebase-admin to defer SDK instantiation until first use.

## Changes
- Wrapped Stripe SDK in lazy Proxy factory
- Moved secret check into lazy initializer
- Preserves all runtime behavior and type safety

## Testing
- Build should complete without "STRIPE_SECRET_KEY is not set" error
- Stripe client functionality unchanged

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>