### PR TITLE
chore(stripe): set real test-mode price IDs for alpha

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -48,11 +48,11 @@ env:
 
   # Stripe price IDs — non-secret, runtime only. Replace placeholders with real price IDs from Stripe Dashboard before enabling checkout.
   - variable: STRIPE_PRICE_STARTER_MONTHLY
-    value: "price_REPLACE_ME_MONTHLY"
+    value: "price_1Q0r0X06TtFrNVu39VXac7MQ"
     availability:
       - RUNTIME
   - variable: STRIPE_PRICE_STARTER_YEARLY
-    value: "price_REPLACE_ME_YEARLY"
+    value: "price_1Q0N5206TtFrNVu3B1rlpJYi"
     availability:
       - RUNTIME
 


### PR DESCRIPTION
## Summary
- Replaced placeholder Stripe price IDs in `apphosting.yaml` with real test-mode IDs
- Unblocks checkout functionality in alpha with webhook and signing secret now configured

## Test plan
- Verify Stripe checkout modal loads and accepts test card (4242 4242 4242 4242)
- Confirm webhook events are received and processed correctly