### PR TITLE
Mobile UX: remove sheet shadow bleed, add edge padding

### DIFF
--- a/app/(app)/(bookings-views)/bookings/bookings-layout.module.css
+++ b/app/(app)/(bookings-views)/bookings/bookings-layout.module.css
@@ -7,7 +7,7 @@
 /* Mobile-only primary action button under the Bookings page title */
 .mobileNewBooking {
   display: none;
-  padding: 0 24px 32px;
+  padding: 0 0 32px;
 }
 
 @media (max-width: 768px) {

--- a/app/(app)/app-layout.module.css
+++ b/app/(app)/app-layout.module.css
@@ -5,7 +5,7 @@
 
 @media (max-width: 768px) {
   .main {
-    padding-left: 0;
-    padding-right: 0;
+    padding-left: 16px;
+    padding-right: 16px;
   }
 }

--- a/components/nav/MobileMenu.module.css
+++ b/components/nav/MobileMenu.module.css
@@ -54,15 +54,15 @@
   width: 280px;
   background: var(--surface-container-low);
   border-left: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: -24px 0 80px rgba(0, 0, 0, 0.6);
   display: flex;
   flex-direction: column;
   transform: translateX(100%);
-  transition: transform 0.25s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .sheetOpen {
   transform: translateX(0);
+  box-shadow: -24px 0 80px rgba(0, 0, 0, 0.6);
 }
 
 /* ── Sheet header ──────────────────────────────────────────────────────────── */

--- a/components/nav/PageHeader.module.css
+++ b/components/nav/PageHeader.module.css
@@ -35,8 +35,8 @@
 
 @media (max-width: 768px) {
   .header {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-left: 8px;
+    padding-right: 8px;
     margin-bottom: 24px;
   }
 }

--- a/components/settings/TeamSettingsView.module.css
+++ b/components/settings/TeamSettingsView.module.css
@@ -240,8 +240,6 @@
 
 @media (max-width: 768px) {
   .container {
-    padding-left: 24px;
-    padding-right: 24px;
     box-sizing: border-box;
     max-width: 100%;
   }


### PR DESCRIPTION
## Summary
- Fix black gradient on right edge — the closed mobile-menu sheet was rendering a leftward box-shadow that bled ~24–80px into the viewport. Shadow now applies only when `.sheetOpen`.
- Add 16px horizontal padding to mobile `main`; reduce PageHeader mobile horizontal padding to 8px so the title's visual position is unchanged (8 + 16 = 24).
- Remove now-redundant 24px side padding from the Bookings mobile-new-booking row and the Team settings container.