### PR TITLE
Mobile: align page title left edge with content (16px)

### DIFF
--- a/components/nav/PageHeader.module.css
+++ b/components/nav/PageHeader.module.css
@@ -35,8 +35,6 @@
 
 @media (max-width: 768px) {
   .header {
-    padding-left: 8px;
-    padding-right: 8px;
     margin-bottom: 24px;
   }
 }


### PR DESCRIPTION
Removes the extra 8px horizontal padding from PageHeader on mobile so titles sit at 16px from the viewport edge, matching the content rows below.