### PR TITLE
New/Edit Booking: align padding, add Full day toggle

### DIFF
--- a/components/bookings/BookingForm.module.css
+++ b/components/bookings/BookingForm.module.css
@@ -86,6 +86,25 @@
   border-color: rgba(255, 255, 255, 0.4);
 }
 
+.fullDayBtnActive {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #221b00;
+  background: var(--white, #ffffff);
+  border: 1px solid var(--white, #ffffff);
+  padding: 3px 8px;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: color 0.1s, border-color 0.1s, background 0.1s;
+}
+
+.fullDayBtnActive:hover {
+  background: rgba(255, 255, 255, 0.85);
+  border-color: rgba(255, 255, 255, 0.85);
+}
+
 .label {
   display: block;
   font-size: 10px;

--- a/components/bookings/BookingForm.module.css
+++ b/components/bookings/BookingForm.module.css
@@ -61,6 +61,31 @@
   color: rgba(255, 255, 255, 0.4);
 }
 
+.sectionLabelRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.fullDayBtn {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.4);
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 3px 8px;
+  cursor: pointer;
+  line-height: 1.4;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.fullDayBtn:hover {
+  color: var(--white);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
 .label {
   display: block;
   font-size: 10px;

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -389,7 +389,16 @@ export default function BookingForm({
           {/* Times — hidden when Full Day (-1) */}
           {timeSlotMinutes !== -1 && (
             <div className={styles.field}>
-              <div className={styles.sectionLabel}>Time</div>
+              <div className={styles.sectionLabelRow}>
+                <div className={styles.sectionLabel}>Time</div>
+                <button
+                  type="button"
+                  className={styles.fullDayBtn}
+                  onClick={() => { setStartTime(''); setEndTime('') }}
+                >
+                  Full day
+                </button>
+              </div>
               <div className={styles.dateRow}>
                 <div>
                   <label className={styles.label} htmlFor="startHour">Start Time</label>

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -65,8 +65,10 @@ export default function BookingForm({
   const [projectName, setProjectName]   = useState(booking?.projectName ?? '')
   const [startDate, setStartDate]       = useState(booking?.startDate ?? defaultStartDate)
   const [endDate, setEndDate]           = useState(booking?.endDate ?? defaultEndDate)
-  const [startTime, setStartTime]       = useState(booking?.startTime ?? '')
-  const [endTime, setEndTime]           = useState(booking?.endTime ?? '')
+  // For a new booking default to 09:00–17:00 so the toggle starts OFF.
+  // For edit: preserve the saved value (null/undefined → '' = all-day = toggle ON).
+  const [startTime, setStartTime]       = useState(booking ? (booking.startTime ?? '') : '09:00')
+  const [endTime, setEndTime]           = useState(booking ? (booking.endTime ?? '') : '17:00')
   const [notes, setNotes]               = useState(booking?.notes ?? '')
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>(initialItems)
   const [error, setError]               = useState<string | null>(null)
@@ -389,68 +391,85 @@ export default function BookingForm({
           {/* Times — hidden when Full Day (-1) */}
           {timeSlotMinutes !== -1 && (
             <div className={styles.field}>
-              <div className={styles.sectionLabelRow}>
-                <div className={styles.sectionLabel}>Time</div>
-                <button
-                  type="button"
-                  className={styles.fullDayBtn}
-                  onClick={() => { setStartTime(''); setEndTime('') }}
-                >
-                  Full day
-                </button>
-              </div>
-              <div className={styles.dateRow}>
-                <div>
-                  <label className={styles.label} htmlFor="startHour">Start Time</label>
-                  <div className={styles.inputWrap}>
-                    <div className={styles.timeRow}>
-                      <select
-                        id="startHour"
-                        className={styles.timeSelect}
-                        value={startHour}
-                        onChange={(e) => handleStartHour(e.target.value)}
+              {(() => {
+                const isFullDay = !startTime && !endTime
+                return (
+                  <>
+                    <div className={styles.sectionLabelRow}>
+                      <div className={styles.sectionLabel}>Time</div>
+                      <button
+                        type="button"
+                        className={isFullDay ? styles.fullDayBtnActive : styles.fullDayBtn}
+                        onClick={() => {
+                          if (isFullDay) {
+                            setStartTime('09:00')
+                            setEndTime('17:00')
+                          } else {
+                            setStartTime('')
+                            setEndTime('')
+                          }
+                        }}
                       >
-                        <option value="">—</option>
-                        {hourOptions.map((h) => <option key={h} value={h}>{h}</option>)}
-                      </select>
-                      <span className={styles.timeSeparator}>:</span>
-                      <select
-                        className={styles.timeSelect}
-                        value={startMinute}
-                        onChange={(e) => handleStartMinute(e.target.value)}
-                        disabled={!startHour}
-                      >
-                        {minuteOptions.map((m) => <option key={m} value={m}>{m}</option>)}
-                      </select>
+                        Full day
+                      </button>
                     </div>
-                  </div>
-                </div>
-                <div>
-                  <label className={styles.label} htmlFor="endHour">End Time</label>
-                  <div className={styles.inputWrap}>
-                    <div className={styles.timeRow}>
-                      <select
-                        id="endHour"
-                        className={styles.timeSelect}
-                        value={endHour}
-                        onChange={(e) => handleEndHour(e.target.value)}
-                      >
-                        <option value="">—</option>
-                        {hourOptions.map((h) => <option key={h} value={h}>{h}</option>)}
-                      </select>
-                      <span className={styles.timeSeparator}>:</span>
-                      <select
-                        className={styles.timeSelect}
-                        value={endMinute}
-                        onChange={(e) => handleEndMinute(e.target.value)}
-                        disabled={!endHour}
-                      >
-                        {minuteOptions.map((m) => <option key={m} value={m}>{m}</option>)}
-                      </select>
-                    </div>
-                  </div>
-                </div>
-              </div>
+                    {!isFullDay && (
+                      <div className={styles.dateRow}>
+                        <div>
+                          <label className={styles.label} htmlFor="startHour">Start Time</label>
+                          <div className={styles.inputWrap}>
+                            <div className={styles.timeRow}>
+                              <select
+                                id="startHour"
+                                className={styles.timeSelect}
+                                value={startHour}
+                                onChange={(e) => handleStartHour(e.target.value)}
+                              >
+                                <option value="">—</option>
+                                {hourOptions.map((h) => <option key={h} value={h}>{h}</option>)}
+                              </select>
+                              <span className={styles.timeSeparator}>:</span>
+                              <select
+                                className={styles.timeSelect}
+                                value={startMinute}
+                                onChange={(e) => handleStartMinute(e.target.value)}
+                                disabled={!startHour}
+                              >
+                                {minuteOptions.map((m) => <option key={m} value={m}>{m}</option>)}
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          <label className={styles.label} htmlFor="endHour">End Time</label>
+                          <div className={styles.inputWrap}>
+                            <div className={styles.timeRow}>
+                              <select
+                                id="endHour"
+                                className={styles.timeSelect}
+                                value={endHour}
+                                onChange={(e) => handleEndHour(e.target.value)}
+                              >
+                                <option value="">—</option>
+                                {hourOptions.map((h) => <option key={h} value={h}>{h}</option>)}
+                              </select>
+                              <span className={styles.timeSeparator}>:</span>
+                              <select
+                                className={styles.timeSelect}
+                                value={endMinute}
+                                onChange={(e) => handleEndMinute(e.target.value)}
+                                disabled={!endHour}
+                              >
+                                {minuteOptions.map((m) => <option key={m} value={m}>{m}</option>)}
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )
+              })()}
             </div>
           )}
 

--- a/components/bookings/BookingFormPage.module.css
+++ b/components/bookings/BookingFormPage.module.css
@@ -1,36 +1,5 @@
-.main {
-  padding: 48px 24px 96px;
-  min-height: 100vh;
-}
-
-@media (min-width: 768px) {
-  .main {
-    padding: 64px 24px 64px;
-  }
-}
-
 .contentWidth {
   max-width: 800px;
   margin-left: auto;
   margin-right: auto;
-}
-
-.header {
-  margin-bottom: 48px;
-}
-
-.h1 {
-  font-size: clamp(2.5rem, 6vw, 3.75rem);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: -0.02em;
-  line-height: 1;
-  color: var(--white);
-  margin-bottom: 24px;
-}
-
-.divider {
-  height: 1px;
-  width: 100%;
-  background: rgba(71, 71, 71, 0.3);
 }

--- a/components/bookings/BookingFormPage.tsx
+++ b/components/bookings/BookingFormPage.tsx
@@ -1,4 +1,5 @@
 import BookingForm from './BookingForm'
+import { PageHeader } from '@/components/nav/PageHeader'
 import type { Booking, Equipment } from '@/types'
 import styles from './BookingFormPage.module.css'
 
@@ -22,12 +23,9 @@ export default function BookingFormPage({
   bookingId,
 }: BookingFormPageProps) {
   return (
-    <main className={styles.main}>
+    <>
+      <PageHeader title="BOOKING" />
       <div className={styles.contentWidth}>
-        <header className={styles.header}>
-          <h1 className={styles.h1}>BOOKING</h1>
-          <div className={styles.divider} />
-        </header>
         <BookingForm
           companyId={companyId}
           equipment={equipment}
@@ -38,6 +36,6 @@ export default function BookingFormPage({
           bookingId={bookingId}
         />
       </div>
-    </main>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- BookingFormPage now uses the shared PageHeader and inherits the app layout's responsive padding (16px mobile / 24px desktop) instead of its own nested `<main>` with fixed 24px.
- Adds a "Full day" toggle in the time section. Derived state from `!startTime && !endTime`. ON → clears times (saves as all-day per schema) and unmounts selects. OFF → restores `09:00`/`17:00`. Existing all-day bookings open with the toggle ON.

## Test plan
- [x] Lint + build clean
- [x] /bookings/new at desktop and mobile
- [x] Toggle on/off restores defaults correctly
- [x] Existing all-day booking edit view opens with toggle ON