### PR TITLE
Mobile: fix booking form right-side whitespace

### DIFF
--- a/components/bookings/BookingForm.module.css
+++ b/components/bookings/BookingForm.module.css
@@ -10,12 +10,13 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  align-items: flex-start;
+  align-items: stretch;
 }
 
 @media (min-width: 768px) {
   .layout {
     flex-direction: row;
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
Sets `align-items: stretch` on the form layout on mobile so the fields column fills full width. Desktop keeps `flex-start` for the sticky summary sidebar.