### PR TITLE
Auth: translate onboarding choice to English, add button styles

### DIFF
--- a/components/auth/Auth.module.css
+++ b/components/auth/Auth.module.css
@@ -158,3 +158,54 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+
+/* Choice screen — mode selection buttons */
+.modeCards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.modeCard {
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--white);
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0;
+  padding: 20px 24px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.modeCard:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Back link — muted text button used above inline forms */
+.backLink {
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.4);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.1s;
+}
+
+.backLink:hover {
+  color: var(--white);
+}

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -222,14 +222,14 @@ export default function SignupForm() {
               type="button"
               onClick={() => setMode('create')}
             >
-              Skapa ett nytt företag
+              Create a new company
             </button>
             <button
               className={styles.modeCard}
               type="button"
               onClick={() => setMode('invite')}
             >
-              Jag har en inbjudningslänk
+              I have an invitation link
             </button>
           </div>
 


### PR DESCRIPTION
Translates the create-company/invitation-link choice from Swedish to English and adds missing CSS for the choice buttons and back link.