### PR TITLE
Fix #170 — Borttagen unit/equipment visas korrekt i gamla bokningar

### DIFF
--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -498,7 +498,7 @@ export async function deactivateUnit(
   equipmentId: string,
   unitId: string,
   force = false,
-): Promise<void | { error: string }> {
+): Promise<void | { error: string } | { requiresForce: true; futureBookingCount: number }> {
   const session = await getVerifiedSession()
   if (!session || session.role !== 'admin') return { error: 'Unauthorized' }
 
@@ -508,18 +508,21 @@ export async function deactivateUnit(
   if (!unitSnap.exists) return { error: 'Unit not found.' }
 
   if (!force) {
+    const todayStr = new Date().toISOString().slice(0, 10)
+
     const bookingsSnap = await adminDb
       .collection('companies').doc(companyId).collection('bookings')
       .where('unitIds', 'array-contains', unitId)
+      .where('endDate', '>=', todayStr)
       .get()
 
-    const activeBookings = bookingsSnap.docs.filter((doc) => {
+    const futureBookings = bookingsSnap.docs.filter((doc) => {
       const data = doc.data()
       return data.status !== 'cancelled' && data.status !== 'returned'
     })
 
-    if (activeBookings.length > 0) {
-      return { error: 'This unit has active bookings. Deactivate or cancel them first.' }
+    if (futureBookings.length > 0) {
+      return { requiresForce: true, futureBookingCount: futureBookings.length }
     }
   }
 

--- a/app/(app)/bookings/[bookingId]/page.tsx
+++ b/app/(app)/bookings/[bookingId]/page.tsx
@@ -19,9 +19,8 @@ export default async function BookingDetailPage({ params, searchParams }: Bookin
   const sp = await searchParams
   const session = await getVerifiedSession()
 
-  const [booking, equipment] = await Promise.all([
+  const [booking] = await Promise.all([
     getBooking(session.activeCompanyId, bookingId),
-    getEquipment(session.activeCompanyId),
   ])
 
   if (!booking) notFound()
@@ -34,7 +33,11 @@ export default async function BookingDetailPage({ params, searchParams }: Bookin
   const isEditing = wantsEdit && canEdit
 
   if (isEditing) {
-    const company = await getCompany(session.activeCompanyId)
+    const [company, equipment] = await Promise.all([
+      getCompany(session.activeCompanyId),
+      // Booking form must only show active equipment so users can't re-book deleted items.
+      getEquipment(session.activeCompanyId),
+    ])
     const timeSlotMinutes = company?.preferences?.bookingTimeSlotMinutes ?? DEFAULT_COMPANY_PREFERENCES.bookingTimeSlotMinutes
 
     return (
@@ -54,6 +57,9 @@ export default async function BookingDetailPage({ params, searchParams }: Bookin
   if (booking.userId) {
     userProfile = await getUserProfile(booking.userId)
   }
+
+  // Fetch with inactive so deleted equipment/units are still named in the pick list.
+  const equipment = await getEquipment(session.activeCompanyId, { includeInactive: true })
 
   return (
     <BookingDetail

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -231,7 +231,11 @@ export default function BookingDetail({
                       <span
                         className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
                       >
-                        {eq?.name ?? item.equipmentId}
+                        {eq
+                          ? eq.active !== false
+                            ? eq.name
+                            : `${eq.name} (deleted)`
+                          : item.equipmentId}
                       </span>
                       <span className={styles.pickItemMeta}>
                         {eq?.category ?? ''}
@@ -241,7 +245,9 @@ export default function BookingDetail({
                         {eq?.trackingType === 'serialized' && unit
                           ? (
                             <span className={styles.pickItemUnit}>
-                              {unit.label}
+                              {unit.active !== false
+                                ? unit.label
+                                : `${unit.label} (deleted)`}
                               {unit.serialNumber ? ` · ${unit.serialNumber}` : ''}
                             </span>
                           )

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { updateEquipmentWithUnits, deactivateEquipment, createEquipmentWithUnits } from '@/actions/equipment'
+import { updateEquipmentWithUnits, deactivateEquipment, createEquipmentWithUnits, deactivateUnit } from '@/actions/equipment'
 import { useCategories } from '@/hooks/useCategories'
 import { useMembers } from '@/hooks/useMembers'
 import type { Equipment, EquipmentStatus, TrackingType, CustomField, CustomFieldList } from '@/types'
@@ -159,9 +159,41 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
     setUnitRows((prev) => prev.map((r) => (r.tempId === tempId ? { ...r, ...patch } : r)))
   }
 
-  function deleteRow(row: UnitRow) {
-    if (row.id) setDeletedIds((prev) => [...prev, row.id!])
-    setUnitRows((prev) => prev.filter((r) => r.tempId !== row.tempId))
+  async function deleteRow(row: UnitRow) {
+    // New (unsaved) rows can be removed immediately — no Firestore check needed.
+    if (!row.id || !equipment) {
+      setUnitRows((prev) => prev.filter((r) => r.tempId !== row.tempId))
+      return
+    }
+
+    setDeleting(true)
+    setError(null)
+
+    const result = await deactivateUnit(equipment.id, row.id)
+
+    if (result && 'requiresForce' in result) {
+      setDeleting(false)
+      const confirmed = confirm(
+        `This unit has ${result.futureBookingCount} future booking(s). Delete anyway?`,
+      )
+      if (!confirmed) return
+      setDeleting(true)
+      const forceResult = await deactivateUnit(equipment.id, row.id, true)
+      setDeleting(false)
+      if (forceResult && 'error' in forceResult) {
+        setError(forceResult.error)
+        return
+      }
+      setDeletedIds((prev) => [...prev, row.id!])
+      setUnitRows((prev) => prev.filter((r) => r.tempId !== row.tempId))
+    } else if (result && 'error' in result) {
+      setDeleting(false)
+      setError(result.error)
+    } else {
+      setDeleting(false)
+      setDeletedIds((prev) => [...prev, row.id!])
+      setUnitRows((prev) => prev.filter((r) => r.tempId !== row.tempId))
+    }
   }
 
   // ── Actions ────────────────────────────────────────────────────────────────

--- a/hooks/useEquipment.ts
+++ b/hooks/useEquipment.ts
@@ -4,7 +4,13 @@ import { collection, collectionGroup, onSnapshot, query, where } from 'firebase/
 import { db } from '@/lib/firebase'
 import type { Equipment, EquipmentUnit } from '@/types'
 
-export function useEquipment(companyId: string) {
+interface UseEquipmentOpts {
+  includeInactive?: boolean
+}
+
+export function useEquipment(companyId: string, opts?: UseEquipmentOpts) {
+  const includeInactive = opts?.includeInactive ?? false
+
   const [equipmentMap, setEquipmentMap] = useState<Map<string, Equipment>>(new Map())
   const [unitsMap, setUnitsMap] = useState<Map<string, EquipmentUnit[]>>(new Map())
   const [loadingEquipment, setLoadingEquipment] = useState(true)
@@ -14,26 +20,33 @@ export function useEquipment(companyId: string) {
   useEffect(() => {
     if (!companyId) return
 
-    const eqQuery = query(
-      collection(db, 'companies', companyId, 'equipment'),
-      where('active', '==', true),
-    )
+    const eqQuery = includeInactive
+      ? query(collection(db, 'companies', companyId, 'equipment'))
+      : query(
+          collection(db, 'companies', companyId, 'equipment'),
+          where('active', '==', true),
+        )
     const unsubEquipment = onSnapshot(eqQuery, (snapshot) => {
       const map = new Map<string, Equipment>()
-      snapshot.docs.forEach((doc) => map.set(doc.id, { id: doc.id, ...doc.data() } as Equipment))
+      snapshot.docs.forEach((doc) => map.set(doc.id, { id: doc.id, active: true, ...doc.data() } as Equipment))
       setEquipmentMap(map)
       setLoadingEquipment(false)
     }, (err) => { setError(err as Error); setLoadingEquipment(false) })
 
-    const unitsQuery = query(
-      collectionGroup(db, 'units'),
-      where('companyId', '==', companyId),
-      where('active', '==', true),
-    )
+    const unitsQuery = includeInactive
+      ? query(
+          collectionGroup(db, 'units'),
+          where('companyId', '==', companyId),
+        )
+      : query(
+          collectionGroup(db, 'units'),
+          where('companyId', '==', companyId),
+          where('active', '==', true),
+        )
     const unsubUnits = onSnapshot(unitsQuery, (snapshot) => {
       const map = new Map<string, EquipmentUnit[]>()
       snapshot.docs.forEach((doc) => {
-        const unit = { id: doc.id, ...doc.data() } as EquipmentUnit
+        const unit = { id: doc.id, active: true, ...doc.data() } as EquipmentUnit
         if (!map.has(unit.equipmentId)) map.set(unit.equipmentId, [])
         map.get(unit.equipmentId)!.push(unit)
       })
@@ -42,7 +55,7 @@ export function useEquipment(companyId: string) {
     }, (err) => { setError(err as Error); setLoadingUnits(false) })
 
     return () => { unsubEquipment(); unsubUnits() }
-  }, [companyId])
+  }, [companyId, includeInactive])
 
   const equipment = useMemo(() => {
     const result: Equipment[] = []

--- a/lib/queries/equipment.ts
+++ b/lib/queries/equipment.ts
@@ -40,23 +40,31 @@ function docToUnit(doc: FirebaseFirestore.DocumentSnapshot): EquipmentUnit {
 }
 
 /**
- * Fetches active equipment for a company, sorted by category then name.
+ * Fetches equipment for a company, sorted by category then name.
  * Uses two parallel queries: parent equipment docs + collectionGroup units,
  * then stitches them together.
  * Wrapped in React.cache — multiple Server Components sharing the same
  * companyId in a single render pass incur only one Firestore read.
+ *
+ * Pass `includeInactive: true` to also return soft-deleted equipment and units.
+ * Default behaviour (false) returns only active items.
  */
-export const getEquipment = cache(async (companyId: string): Promise<Equipment[]> => {
+export const getEquipment = cache(async (
+  companyId: string,
+  opts?: { includeInactive?: boolean },
+): Promise<Equipment[]> => {
+  const includeInactive = opts?.includeInactive ?? false
+
   const [eqSnapshot, unitsSnapshot] = await Promise.all([
-    adminDb.collection('companies').doc(companyId).collection('equipment')
-      .where('active', '==', true)
-      .orderBy('category', 'asc')
-      .orderBy('name', 'asc')
-      .get(),
-    adminDb.collectionGroup('units')
-      .where('companyId', '==', companyId)
-      .where('active', '==', true)
-      .get(),
+    (() => {
+      const ref = adminDb.collection('companies').doc(companyId).collection('equipment')
+      const q = includeInactive ? ref : ref.where('active', '==', true)
+      return q.orderBy('category', 'asc').orderBy('name', 'asc').get()
+    })(),
+    (() => {
+      const ref = adminDb.collectionGroup('units').where('companyId', '==', companyId)
+      return (includeInactive ? ref : ref.where('active', '==', true)).get()
+    })(),
   ])
 
   const unitsMap = new Map<string, EquipmentUnit[]>()

--- a/lib/queries/equipment.ts
+++ b/lib/queries/equipment.ts
@@ -62,8 +62,13 @@ export const getEquipment = cache(async (
       return q.orderBy('category', 'asc').orderBy('name', 'asc').get()
     })(),
     (() => {
-      const ref = adminDb.collectionGroup('units').where('companyId', '==', companyId)
-      return (includeInactive ? ref : ref.where('active', '==', true)).get()
+      const base = adminDb.collectionGroup('units').where('companyId', '==', companyId)
+      if (!includeInactive) return base.where('active', '==', true).get()
+      // Run two queries to reuse existing (companyId, active) composite index
+      return Promise.all([
+        base.where('active', '==', true).get(),
+        base.where('active', '==', false).get(),
+      ]).then(([a, b]) => ({ docs: [...a.docs, ...b.docs] }))
     })(),
   ])
 


### PR DESCRIPTION
## Summary
- Bokningsdetaljvyn hämtar nu även inaktivt (borttaget) equipment och units, och visar `(deleted)` efter namnet istället för ett Firestore-ID eller ingenting
- Ny varning visas när man tar bort en unit som har framtida bokningar — användaren kan avbryta eller fortsätta
- `deactivateUnit` returnerar nu `requiresForce` (istället för error) vid framtida bokningar, så att UI kan visa en confirm-dialog

## Changes
- `hooks/useEquipment.ts` — `includeInactive` option + default `active: true` för gamla dokument
- `lib/queries/equipment.ts` — `includeInactive` option på server-side query
- `app/(app)/bookings/[bookingId]/page.tsx` — `includeInactive: true` för detaljvyn
- `components/bookings/BookingDetail.tsx` — visar `(deleted)` för inaktivt equipment/unit
- `actions/equipment.ts` — `deactivateUnit` hanterar framtida bokningar med `requiresForce`
- `components/equipment/EquipmentEditModal.tsx` — tvåstegs-confirm vid unit-borttag

## Test plan
- [ ] Deaktivera ett equipment → gamla bokningar ska visa `"Namn (deleted)"` istället för Firestore-ID
- [ ] Deaktivera en unit → gamla bokningar ska visa `"Label (deleted)"`
- [ ] Ta bort en unit med framtida bokningar → varning ska visas med antal bokningar
- [ ] Ta bort en unit utan framtida bokningar → går direkt utan varning
- [ ] Equipment-lista och bokningsformulär visar bara aktiva units/equipment (oförändrat)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)