### PR TITLE
fix(equipment): rename trackingType 'serialized' → 'units' (#172)

### DIFF
--- a/__tests__/equipment/createEquipmentWithUnits.test.ts
+++ b/__tests__/equipment/createEquipmentWithUnits.test.ts
@@ -63,7 +63,7 @@ const VALID_FIELDS = {
   name: 'ARRI Alexa Mini LF',
   description: null,
   category: 'Camera',
-  trackingType: 'serialized' as const,
+  trackingType: 'units' as const,
   totalQuantity: 1,
   requiresApproval: false,
   approverId: null,

--- a/__tests__/equipment/planLimit.test.ts
+++ b/__tests__/equipment/planLimit.test.ts
@@ -96,7 +96,7 @@ const VALID_FIELDS = {
   name: 'ARRI Alexa Mini LF',
   description: null,
   category: 'Camera',
-  trackingType: 'serialized' as const,
+  trackingType: 'units' as const,
   totalQuantity: 1,
   requiresApproval: false,
   approverId: null,

--- a/__tests__/equipment/updateEquipmentWithUnits.test.ts
+++ b/__tests__/equipment/updateEquipmentWithUnits.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/firebase-admin', () => {
       data: () => ({
         name: 'ARRI Alexa Mini LF',
         category: 'Camera',
-        trackingType: 'serialized',
+        trackingType: 'units',
         active: true,
       }),
     }),
@@ -106,7 +106,7 @@ beforeEach(() => {
       data: () => ({
         name: 'ARRI Alexa Mini LF',
         category: 'Camera',
-        trackingType: 'serialized',
+        trackingType: 'units',
         active: true,
       }),
     }),

--- a/actions/bookings.ts
+++ b/actions/bookings.ts
@@ -17,7 +17,7 @@ interface EquipmentDocumentInternal {
   name: string
   active: boolean
   availableForBooking?: boolean
-  trackingType: 'serialized' | 'quantity'
+  trackingType: 'units' | 'quantity'
   totalQuantity: number
   requiresApproval: boolean
   approverId: string | null
@@ -165,7 +165,7 @@ async function detectConflictsReadOnly(
 
     const equipment = equipmentSnap.data() as EquipmentDocumentInternal
 
-    if (equipment.trackingType === 'serialized') {
+    if (equipment.trackingType === 'units') {
       // For serialized items, conflict is per-unit, not per-equipment-type.
       if (!item.unitId) {
         conflicts.push({
@@ -288,7 +288,7 @@ async function detectConflictsInTransaction(
 
     const equipment = equipmentSnap.data() as EquipmentDocumentInternal
 
-    if (equipment.trackingType === 'serialized') {
+    if (equipment.trackingType === 'units') {
       // For serialized items, conflict is per-unit, not per-equipment-type.
       if (!item.unitId) {
         conflicts.push({
@@ -481,15 +481,15 @@ export async function createBooking(
           throw new Error('Some selected equipment is not available for booking.')
         }
 
-        if (equipment.trackingType === 'serialized') {
+        if (equipment.trackingType === 'units') {
           if (item.quantity !== 1) {
             throw new Error(
-              `Equipment "${equipment.name}" is serialized; quantity must be 1.`,
+              `Equipment "${equipment.name}" is unit-tracked; quantity must be 1.`,
             )
           }
           if (!item.unitId) {
             throw new Error(
-              `Equipment "${equipment.name}" is serialized; unitId is required.`,
+              `Equipment "${equipment.name}" is unit-tracked; unitId is required.`,
             )
           }
         }
@@ -712,9 +712,9 @@ export async function updateBooking(
             throw new Error(`Equipment "${equipment.name}" is not available (deactivated).`)
           }
 
-          if (equipment.trackingType === 'serialized' && item.quantity !== 1) {
+          if (equipment.trackingType === 'units' && item.quantity !== 1) {
             throw new Error(
-              `Equipment "${equipment.name}" is serialized; quantity must be 1.`,
+              `Equipment "${equipment.name}" is unit-tracked; quantity must be 1.`,
             )
           }
 

--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -39,7 +39,7 @@ export async function createEquipment(
   const description = (formData.get('description') as string | null)?.trim() || null
 
   const trackingType =
-    (formData.get('trackingType') as string | null) === 'quantity' ? 'quantity' : 'serialized'
+    (formData.get('trackingType') as string | null) === 'quantity' ? 'quantity' : 'units'
 
   let totalQuantity = 1
   if (trackingType === 'quantity') {
@@ -322,7 +322,7 @@ export async function deactivateEquipment(
     // Units are deactivated in a separate batch after the transaction. If this batch fails,
     // the parent equipment is already deactivated and the counter is correct, but child units
     // remain active=true. A cleanup job or retry is needed in that case.
-    if (trackingType === 'serialized') {
+    if (trackingType === 'units') {
       const unitsSnap = await equipmentRef.collection('units').where('active', '==', true).get()
       if (unitsSnap.size > 0) {
         const batch = adminDb.batch()
@@ -431,7 +431,7 @@ export async function createUnit(
   if (!parentSnap.exists) return { error: 'Equipment not found.' }
 
   const parent = parentSnap.data()!
-  if (parent.trackingType !== 'serialized') return { error: 'Units can only be added to serialized equipment.' }
+  if (parent.trackingType !== 'units') return { error: 'Units can only be added to unit-tracked equipment.' }
   if (!parent.active) return { error: 'Cannot add units to deactivated equipment.' }
 
   const label = (formData.get('label') as string | null)?.trim() ?? ''

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -242,7 +242,7 @@ export default function BookingDetail({
                         {eq?.trackingType === 'quantity' && item.quantity > 1
                           ? <span className={styles.pickItemQty}>&times;{item.quantity}</span>
                           : null}
-                        {eq?.trackingType === 'serialized' && unit
+                        {eq?.trackingType === 'units' && unit
                           ? (
                             <span className={styles.pickItemUnit}>
                               {unit.active !== false

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -174,7 +174,7 @@ export default function BookingForm({
     setConflictResult(null)
   }
 
-  function sortedSerializedUnits(eq: Equipment): NonNullable<typeof eq.units> {
+  function sortedUnits(eq: Equipment): NonNullable<typeof eq.units> {
     const bookable = (eq.units ?? []).filter(u => u.availableForBooking !== false)
     const booked = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
     const available   = bookable.filter(u => !booked.has(u.id)).sort((a, b) => a.label.localeCompare(b.label))
@@ -182,8 +182,8 @@ export default function BookingForm({
     return [...available, ...unavailable]
   }
 
-  function toggleSerializedItem(eq: Equipment) {
-    const sorted = sortedSerializedUnits(eq)
+  function toggleUnitItem(eq: Equipment) {
+    const sorted = sortedUnits(eq)
     setSelectedItems((prev) => {
       const hasSelection = prev.some((i) => i.equipmentId === eq.id && i.unitId)
       if (hasSelection) {
@@ -493,8 +493,8 @@ export default function BookingForm({
                     {items.map((eq) => {
                       const hasConflict = conflictIds.has(eq.id)
 
-                      if (eq.trackingType === 'serialized') {
-                        const units = sortedSerializedUnits(eq)
+                      if (eq.trackingType === 'units') {
+                        const units = sortedUnits(eq)
                         const selectedUnitId = getSelectedUnitId(eq.id)
                         const isChecked = !!selectedUnitId
 
@@ -513,7 +513,7 @@ export default function BookingForm({
                                 type="checkbox"
                                 className={styles.hiddenCheckbox}
                                 checked={isChecked}
-                                onChange={() => toggleSerializedItem(eq)}
+                                onChange={() => toggleUnitItem(eq)}
                               />
                               <div className={styles.equipmentMeta}>
                                 <span className={styles.equipmentName}>{eq.name}</span>

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -43,7 +43,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
   const [approverId, setApproverId] = useState(equipment?.approverId ?? '')
 
   // Create-mode fields
-  const [trackingType, setTrackingType] = useState<TrackingType>(equipment?.trackingType ?? 'serialized')
+  const [trackingType, setTrackingType] = useState<TrackingType>(equipment?.trackingType ?? 'units')
   const [totalQuantity, setTotalQuantity] = useState(equipment?.totalQuantity ?? 1)
   const [customFields, setCustomFields] = useState<CustomField[]>(equipment?.customFields ?? [])
 
@@ -99,7 +99,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
     setDescription(equipment?.description ?? '')
     setRequiresApproval(equipment?.requiresApproval ?? false)
     setApproverId(equipment?.approverId ?? '')
-    setTrackingType(equipment?.trackingType ?? 'serialized')
+    setTrackingType(equipment?.trackingType ?? 'units')
     setTotalQuantity(equipment?.totalQuantity ?? 1)
     setCustomFields(equipment?.customFields ?? [])
     setDeletedIds([])
@@ -256,7 +256,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
         customFields,
       }
 
-      const unitCreates: UnitCreate[] = trackingType === 'serialized'
+      const unitCreates: UnitCreate[] = trackingType === 'units'
         ? unitRows.map((r) => ({
             label: r.label,
             serialNumber: r.serialNumber,
@@ -416,11 +416,11 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
             <div className={styles.trackingToggleGroup}>
               <button
                 type="button"
-                className={`${styles.trackingToggleBtn} ${trackingType === 'serialized' ? styles.trackingToggleBtnActive : ''}`}
-                onClick={() => { if (!isEditMode) setTrackingType('serialized') }}
+                className={`${styles.trackingToggleBtn} ${trackingType === 'units' ? styles.trackingToggleBtnActive : ''}`}
+                onClick={() => { if (!isEditMode) setTrackingType('units') }}
                 disabled={isEditMode}
               >
-                Serialized (individual units)
+                Units (individual)
               </button>
               <button
                 type="button"
@@ -527,8 +527,8 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
             </div>
           )}
 
-          {/* Section D: Units — serialized only */}
-          {trackingType === 'serialized' && (
+          {/* Section D: Units — unit-tracked only */}
+          {trackingType === 'units' && (
             <div className={styles.section}>
               <p className={styles.sectionLabel}>Units</p>
 

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -137,9 +137,9 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
           {categories.map((cat) => {
             const items = grouped[cat]
 
-            // Separate quantity items (flat) from serialized items (group header + unit rows)
+            // Separate quantity items (flat) from unit-tracked items (group header + unit rows)
             const quantityItems = items.filter((i) => i.trackingType === 'quantity' || !i.trackingType)
-            const serializedItems = items.filter((i) => i.trackingType === 'serialized')
+            const unitItems = items.filter((i) => i.trackingType === 'units')
 
             return (
               <section key={cat} className={styles.category}>
@@ -197,8 +197,8 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
                   </div>
                 ))}
 
-                {/* Serialized items — collapsible group with unified edit modal */}
-                {serializedItems.map((eq) => (
+                {/* Unit-tracked items — collapsible group with unified edit modal */}
+                {unitItems.map((eq) => (
                   <details key={eq.id} className={styles.group}>
                     <summary className={styles.groupHeader}>
                       <div className={styles.rowLeft}>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -34,6 +34,14 @@
       ]
     },
     {
+      "collectionGroup": "equipment",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "name", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "bookings",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/src/bookings/conflictDetection.ts
+++ b/functions/src/bookings/conflictDetection.ts
@@ -21,7 +21,7 @@ export interface BookingItemInput {
 }
 
 export interface EquipmentData {
-  trackingType: 'serialized' | 'quantity';
+  trackingType: 'units' | 'quantity';
   totalQuantity: number;
   name: string;
   active: boolean;
@@ -129,7 +129,7 @@ export async function detectConflictsReadOnly(
       return timesOverlap(requested, data);
     });
 
-    if (equipment.trackingType === 'serialized') {
+    if (equipment.trackingType === 'units') {
       if (overlapping.length > 0) {
         conflicts.push({
           equipmentId: item.equipmentId,
@@ -217,7 +217,7 @@ export async function detectConflictsInTransaction(
       return timesOverlap(requested, data);
     });
 
-    if (equipment.trackingType === 'serialized') {
+    if (equipment.trackingType === 'units') {
       if (overlapping.length > 0) {
         conflicts.push({
           equipmentId: item.equipmentId,

--- a/functions/src/bookings/createBooking.ts
+++ b/functions/src/bookings/createBooking.ts
@@ -160,10 +160,10 @@ export const createBooking = onCall({ region: 'europe-west1', cors: true, invoke
         );
       }
 
-      if (equipment.trackingType === 'serialized' && item.quantity !== 1) {
+      if (equipment.trackingType === 'units' && item.quantity !== 1) {
         throw new HttpsError(
           'invalid-argument',
-          `Equipment "${equipment.name}" is serialized; quantity must be 1.`,
+          `Equipment "${equipment.name}" is unit-tracked; quantity must be 1.`,
         );
       }
 

--- a/functions/src/bookings/updateBooking.ts
+++ b/functions/src/bookings/updateBooking.ts
@@ -193,10 +193,10 @@ export const updateBooking = onCall({ region: 'europe-west1', cors: true, invoke
           );
         }
 
-        if (equipment.trackingType === 'serialized' && item.quantity !== 1) {
+        if (equipment.trackingType === 'units' && item.quantity !== 1) {
           throw new HttpsError(
             'invalid-argument',
-            `Equipment "${equipment.name}" is serialized; quantity must be 1.`,
+            `Equipment "${equipment.name}" is unit-tracked; quantity must be 1.`,
           );
         }
 

--- a/functions/src/equipment/addEquipment.ts
+++ b/functions/src/equipment/addEquipment.ts
@@ -12,7 +12,7 @@ import { validateCustomFields } from './validateCustomFields';
  * @param data.companyId         - Company to add equipment to
  * @param data.name              - Display name (required, max 100 chars)
  * @param data.category          - Category label (required)
- * @param data.trackingType      - 'serialized' or 'quantity' (required, immutable after creation)
+ * @param data.trackingType      - 'units' or 'quantity' (required, immutable after creation)
  * @param data.totalQuantity     - Pool size for quantity items; forced to 1 for individual items
  * @param data.serialNumber      - Optional serial number for individual items; rejected on quantity items
  * @param data.status            - Initial status; defaults to 'available'
@@ -96,7 +96,7 @@ export const addEquipment = onCall({ region: 'europe-west1', cors: true, invoker
   const customFields = validateCustomFields(request.data.customFields);
 
   // ── trackingType validation ────────────────────────────────────────────────
-  const VALID_TRACKING_TYPES = ['serialized', 'quantity'] as const;
+  const VALID_TRACKING_TYPES = ['units', 'quantity'] as const;
   type TrackingType = typeof VALID_TRACKING_TYPES[number];
 
   const rawTrackingType: unknown = request.data.trackingType;
@@ -117,14 +117,14 @@ export const addEquipment = onCall({ region: 'europe-west1', cors: true, invoker
     }
     totalQuantity = rawQty;
   }
-  // For serialized items totalQuantity is always 1, regardless of what the client sends.
+  // For unit-tracked items totalQuantity is always 1, regardless of what the client sends.
 
   // ── serialNumber validation ────────────────────────────────────────────────
   let serialNumber: string | null = null;
   if (trackingType === 'quantity' && request.data.serialNumber !== undefined && request.data.serialNumber !== null) {
     throw new HttpsError('invalid-argument', 'serialNumber is not allowed for quantity-tracked items.');
   }
-  if (trackingType === 'serialized' && request.data.serialNumber) {
+  if (trackingType === 'units' && request.data.serialNumber) {
     serialNumber = String(request.data.serialNumber).trim() || null;
   }
 

--- a/functions/src/equipment/updateEquipment.ts
+++ b/functions/src/equipment/updateEquipment.ts
@@ -141,9 +141,9 @@ export const updateEquipment = onCall({ region: 'europe-west1', cors: true, invo
     updates['customFields'] = validateCustomFields(request.data.customFields);
   }
 
-  // ── serialNumber — only valid for serialized items ────────────────────────
+  // ── serialNumber — only valid for unit-tracked items ─────────────────────
   if (request.data.serialNumber !== undefined) {
-    if (existingData.trackingType !== 'serialized') {
+    if (existingData.trackingType !== 'units') {
       throw new HttpsError('invalid-argument', 'serialNumber is not allowed on quantity-tracked items.');
     }
     updates['serialNumber'] = request.data.serialNumber

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -105,7 +105,7 @@ export interface BookingDocument {
 
 // ─── Equipment documents ───────────────────────────────────────────────────────
 
-export type TrackingType = 'serialized' | 'quantity';
+export type TrackingType = 'units' | 'quantity';
 
 export interface EquipmentDocument {
   name: string;

--- a/hooks/useEquipment.ts
+++ b/hooks/useEquipment.ts
@@ -62,7 +62,7 @@ export function useEquipment(companyId: string, opts?: UseEquipmentOpts) {
     for (const eq of equipmentMap.values()) {
       result.push({
         ...eq,
-        units: eq.trackingType === 'serialized' ? (unitsMap.get(eq.id) ?? []) : undefined,
+        units: eq.trackingType === 'units' ? (unitsMap.get(eq.id) ?? []) : undefined,
       })
     }
     return result.sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name))

--- a/lib/queries/equipment.ts
+++ b/lib/queries/equipment.ts
@@ -13,7 +13,7 @@ function docToEquipment(doc: FirebaseFirestore.DocumentSnapshot): Equipment {
     category:         data.category         ?? '',
     icon:             data.icon             ?? undefined,
     active:           data.active           ?? true,
-    trackingType:     data.trackingType     ?? 'serialized',
+    trackingType:     data.trackingType     ?? 'units',
     totalQuantity:    data.totalQuantity    ?? 1,
     requiresApproval:     data.requiresApproval     ?? false,
     approverId:           data.approverId           ?? null,
@@ -83,7 +83,7 @@ export const getEquipment = cache(async (
     const eq = docToEquipment(doc)
     return {
       ...eq,
-      units: eq.trackingType === 'serialized' ? (unitsMap.get(eq.id) ?? []) : undefined,
+      units: eq.trackingType === 'units' ? (unitsMap.get(eq.id) ?? []) : undefined,
     }
   })
 })

--- a/tools/migrate_serialized_to_units.js
+++ b/tools/migrate_serialized_to_units.js
@@ -1,34 +1,73 @@
-// Migration: rename trackingType 'serialized' → 'units' (issue #172)
-// Run once with: npx ts-node tools/migrate_serialized_to_units.ts
-// Prerequisites: GOOGLE_APPLICATION_CREDENTIALS set, or gcloud auth application-default login
+/**
+ * Migration: rename trackingType 'serialized' → 'units' (issue #172)
+ *
+ * Updates all equipment documents where trackingType === 'serialized' to 'units'.
+ * Scope: companies/{companyId}/equipment/{equipmentId}
+ *
+ * Run from the repo root:
+ *   node tools/migrate_serialized_to_units.js
+ * Prerequisites: FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON in .env.local
+ */
 
 'use strict';
 
-import { initializeApp, applicationDefault } from 'firebase-admin/app';
-import { getFirestore, WriteBatch } from 'firebase-admin/firestore';
+const fs = require('fs');
+const path = require('path');
 
 // ---------------------------------------------------------------------------
-// 1. Initialise Firebase Admin with Application Default Credentials
+// 1. Load .env.local (same pattern as migrate_unit_status.js)
 // ---------------------------------------------------------------------------
-initializeApp({
-  credential: applicationDefault(),
-  projectId: 'allocate-e0735',
-});
+const ENV_PATH = path.resolve(__dirname, '../.env.local');
+
+function loadEnvFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const vars = {};
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    vars[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
+  }
+  return vars;
+}
+
+const env = loadEnvFile(ENV_PATH);
+const serviceAccountJson = env['FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON'];
+if (!serviceAccountJson) {
+  console.error('ERROR: FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON not found in .env.local');
+  process.exit(1);
+}
+
+let serviceAccount;
+try {
+  serviceAccount = JSON.parse(serviceAccountJson);
+} catch (err) {
+  console.error('ERROR: Failed to parse FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON:', err.message);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Initialise Firebase Admin
+// ---------------------------------------------------------------------------
+const { initializeApp, cert } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
+
+initializeApp({ credential: cert(serviceAccount) });
 
 const db = getFirestore();
-db.settings({ preferRest: false }); // use gRPC (default); remove if you hit auth issues with ADC
 
 // ---------------------------------------------------------------------------
-// 2. Constants
+// 3. Constants
 // ---------------------------------------------------------------------------
-const BATCH_SIZE = 499; // Firestore batched write max is 500 operations
+const BATCH_SIZE = 499;
 const OLD_VALUE = 'serialized';
 const NEW_VALUE = 'units';
 
 // ---------------------------------------------------------------------------
-// 3. Migration
+// 4. Migration
 // ---------------------------------------------------------------------------
-async function migrate(): Promise<void> {
+async function migrate() {
   console.log(`Migration started: trackingType '${OLD_VALUE}' → '${NEW_VALUE}'`);
   console.log('Listing companies...');
 
@@ -85,10 +124,9 @@ async function migrate(): Promise<void> {
       `  [${companyId}] ${equipmentSnapshot.size} equipment doc(s) checked — updating ${docsToUpdate.length}.`
     );
 
-    // Split into batches of BATCH_SIZE
     for (let i = 0; i < docsToUpdate.length; i += BATCH_SIZE) {
       const chunk = docsToUpdate.slice(i, i + BATCH_SIZE);
-      const batch: WriteBatch = db.batch();
+      const batch = db.batch();
 
       for (const docSnap of chunk) {
         batch.update(docSnap.ref, { trackingType: NEW_VALUE });
@@ -106,7 +144,6 @@ async function migrate(): Promise<void> {
           `    ERROR: Batch commit failed for company '${companyId}' (offset ${i}):`,
           err
         );
-        // Continue to next batch rather than aborting the entire migration
       }
     }
   }

--- a/tools/migrate_serialized_to_units.ts
+++ b/tools/migrate_serialized_to_units.ts
@@ -1,0 +1,122 @@
+// Migration: rename trackingType 'serialized' → 'units' (issue #172)
+// Run once with: npx ts-node tools/migrate_serialized_to_units.ts
+// Prerequisites: GOOGLE_APPLICATION_CREDENTIALS set, or gcloud auth application-default login
+
+'use strict';
+
+import { initializeApp, applicationDefault } from 'firebase-admin/app';
+import { getFirestore, WriteBatch } from 'firebase-admin/firestore';
+
+// ---------------------------------------------------------------------------
+// 1. Initialise Firebase Admin with Application Default Credentials
+// ---------------------------------------------------------------------------
+initializeApp({
+  credential: applicationDefault(),
+  projectId: 'allocate-e0735',
+});
+
+const db = getFirestore();
+db.settings({ preferRest: false }); // use gRPC (default); remove if you hit auth issues with ADC
+
+// ---------------------------------------------------------------------------
+// 2. Constants
+// ---------------------------------------------------------------------------
+const BATCH_SIZE = 499; // Firestore batched write max is 500 operations
+const OLD_VALUE = 'serialized';
+const NEW_VALUE = 'units';
+
+// ---------------------------------------------------------------------------
+// 3. Migration
+// ---------------------------------------------------------------------------
+async function migrate(): Promise<void> {
+  console.log(`Migration started: trackingType '${OLD_VALUE}' → '${NEW_VALUE}'`);
+  console.log('Listing companies...');
+
+  let companiesSnapshot;
+  try {
+    companiesSnapshot = await db.collection('companies').get();
+  } catch (err) {
+    console.error('ERROR: Failed to list companies collection:', err);
+    process.exit(1);
+  }
+
+  if (companiesSnapshot.empty) {
+    console.log('No company documents found. Nothing to migrate.');
+    return;
+  }
+
+  console.log(`Found ${companiesSnapshot.size} company document(s).\n`);
+
+  let totalUpdated = 0;
+  let totalBatches = 0;
+
+  for (const companyDoc of companiesSnapshot.docs) {
+    const companyId = companyDoc.id;
+
+    let equipmentSnapshot;
+    try {
+      equipmentSnapshot = await db
+        .collection('companies')
+        .doc(companyId)
+        .collection('equipment')
+        .get();
+    } catch (err) {
+      console.error(`  [${companyId}] ERROR: Failed to list equipment — skipping company:`, err);
+      continue;
+    }
+
+    if (equipmentSnapshot.empty) {
+      console.log(`  [${companyId}] No equipment documents — skipping.`);
+      continue;
+    }
+
+    const docsToUpdate = equipmentSnapshot.docs.filter(
+      (doc) => doc.data().trackingType === OLD_VALUE
+    );
+
+    if (docsToUpdate.length === 0) {
+      console.log(
+        `  [${companyId}] ${equipmentSnapshot.size} equipment doc(s) checked — 0 need updating.`
+      );
+      continue;
+    }
+
+    console.log(
+      `  [${companyId}] ${equipmentSnapshot.size} equipment doc(s) checked — updating ${docsToUpdate.length}.`
+    );
+
+    // Split into batches of BATCH_SIZE
+    for (let i = 0; i < docsToUpdate.length; i += BATCH_SIZE) {
+      const chunk = docsToUpdate.slice(i, i + BATCH_SIZE);
+      const batch: WriteBatch = db.batch();
+
+      for (const docSnap of chunk) {
+        batch.update(docSnap.ref, { trackingType: NEW_VALUE });
+      }
+
+      try {
+        await batch.commit();
+        totalUpdated += chunk.length;
+        totalBatches++;
+        console.log(
+          `    Batch ${totalBatches} committed: ${chunk.length} doc(s) updated for company '${companyId}'.`
+        );
+      } catch (err) {
+        console.error(
+          `    ERROR: Batch commit failed for company '${companyId}' (offset ${i}):`,
+          err
+        );
+        // Continue to next batch rather than aborting the entire migration
+      }
+    }
+  }
+
+  console.log(
+    `\nMigration complete. ${totalUpdated} equipment document(s) updated across ${totalBatches} batch(es).`
+  );
+}
+
+migrate().catch((err) => {
+  console.error('Unhandled error — migration aborted:', err);
+  process.exit(1);
+});

--- a/types/booking.ts
+++ b/types/booking.ts
@@ -9,11 +9,11 @@ export type BookingStatus = 'pending' | 'confirmed' | 'checked_out' | 'returned'
 export type ApprovalStatus = 'none' | 'pending' | 'approved' | 'rejected'
 
 // One entry per equipment item included in the booking.
-// quantity is always 1 for serialized-tracked items.
+// quantity is always 1 for unit-tracked items.
 export interface BookingItem {
   equipmentId: string
   quantity: number
-  unitId?: string   // set for serialized items; identifies the specific physical unit
+  unitId?: string   // set for unit-tracked items; identifies the specific physical unit
 }
 
 export interface Booking {
@@ -22,7 +22,7 @@ export interface Booking {
   notes: string
   items: BookingItem[]
   equipmentIds: string[]         // denormalized for query indexing; derived from items
-  unitIds?: string[]             // denormalized; all unitId values from serialized items
+  unitIds?: string[]             // denormalized; all unitId values from unit-tracked items
   startDate: string              // "YYYY-MM-DD" — inclusive
   endDate: string                // "YYYY-MM-DD" — inclusive
   startTime?: string | null      // "HH:MM" — null/absent means all-day

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -1,8 +1,8 @@
 export type EquipmentStatus = 'ok' | 'needs_repair' | 'limited_operations'
 
-// 'serialized' = one parent doc per equipment type, one subcollection doc per physical unit
-// 'quantity'   = one document represents a pool of interchangeable items
-export type TrackingType = 'serialized' | 'quantity'
+// 'units'    = one parent doc per equipment type, one subcollection doc per physical unit
+// 'quantity' = one document represents a pool of interchangeable items
+export type TrackingType = 'units' | 'quantity'
 
 // Default categories seeded for every new company
 export const DEFAULT_EQUIPMENT_CATEGORIES = [
@@ -49,7 +49,7 @@ export interface Equipment {
   icon?: string
   active: boolean
   trackingType: TrackingType  // immutable after creation
-  totalQuantity: number       // always 1 for serialized; >= 1 for quantity
+  totalQuantity: number       // always 1 for unit-tracked items; >= 1 for quantity
   requiresApproval: boolean   // triggers approval flow when booked
   approverId: string | null   // specific user who must approve; Admin if null
   availableForBooking: boolean // when false, hidden from the booking form picker


### PR DESCRIPTION
## Summary
- Renames the `'serialized'` TrackingType value to `'units'` across all source files — types, Cloud Functions, Server Actions, React components, hooks, and tests
- Updates variable/function names derived from "serialized" (`serializedItems` → `unitItems`, `sortedSerializedUnits` → `sortedUnits`, `toggleSerializedItem` → `toggleUnitItem`)
- Adds `tools/migrate_serialized_to_units.ts` — a one-time script to update existing Firestore documents where `trackingType === 'serialized'`
- Includes a pre-existing Firestore index addition for `equipment` (category + name)

Closes #172

## Test plan
- [ ] Run `npm test` — all passing tests continue to pass (7 pre-existing failures in `deleteAccount`, `conflictDetection`, and `createBooking` tests are unaffected)
- [ ] Run `npm run build` in `functions/` — TypeScript compiles without errors
- [ ] Run migration script against dev Firestore: `npx ts-node tools/migrate_serialized_to_units.ts`
- [ ] Verify equipment creation/booking flow in the app with trackingType `'units'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)