### PR TITLE
fix(#171): make qty and unit rows visually consistent

### DIFF
--- a/actions/equipment.ts
+++ b/actions/equipment.ts
@@ -564,6 +564,7 @@ export interface EquipmentFields {
   description: string | null
   requiresApproval: boolean
   approverId: string | null
+  availableForBooking?: boolean
   customFields: CustomField[]
 }
 
@@ -632,6 +633,7 @@ export async function updateEquipmentWithUnits(
       description: equipment.description?.trim() || null,
       requiresApproval: equipment.requiresApproval,
       approverId: equipment.approverId || null,
+      ...(equipment.availableForBooking !== undefined && { availableForBooking: equipment.availableForBooking }),
       customFields: equipment.customFields,
       updatedAt: FieldValue.serverTimestamp(),
       updatedBy: session.uid,

--- a/components/equipment/EquipmentEditModal.tsx
+++ b/components/equipment/EquipmentEditModal.tsx
@@ -45,6 +45,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
   // Create-mode fields
   const [trackingType, setTrackingType] = useState<TrackingType>(equipment?.trackingType ?? 'units')
   const [totalQuantity, setTotalQuantity] = useState(equipment?.totalQuantity ?? 1)
+  const [availableForBooking, setAvailableForBooking] = useState(equipment?.availableForBooking ?? true)
   const [customFields, setCustomFields] = useState<CustomField[]>(equipment?.customFields ?? [])
 
   // When category changes in create mode, populate custom fields from templates
@@ -101,6 +102,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
     setApproverId(equipment?.approverId ?? '')
     setTrackingType(equipment?.trackingType ?? 'units')
     setTotalQuantity(equipment?.totalQuantity ?? 1)
+    setAvailableForBooking(equipment?.availableForBooking ?? true)
     setCustomFields(equipment?.customFields ?? [])
     setDeletedIds([])
     setError(null)
@@ -209,6 +211,7 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
         description: description.trim() || null,
         requiresApproval,
         approverId: approverId || null,
+        availableForBooking,
         customFields,
       }
 
@@ -432,17 +435,33 @@ export default function EquipmentEditModal({ isOpen, onClose, companyId, equipme
               </button>
             </div>
             {trackingType === 'quantity' && (
-              <div className={`${styles.field} ${styles.fieldMt}`}>
-                <label className={styles.fieldLabel}>Total Quantity</label>
-                <input
-                  type="number"
-                  min={1}
-                  value={totalQuantity}
-                  onChange={(e) => setTotalQuantity(Math.max(1, parseInt(e.target.value, 10) || 1))}
-                  className={styles.input}
-                  disabled={isEditMode}
-                />
-              </div>
+              <>
+                <div className={`${styles.field} ${styles.fieldMt}`}>
+                  <label className={styles.fieldLabel}>Total Quantity</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={totalQuantity}
+                    onChange={(e) => setTotalQuantity(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                    className={styles.input}
+                    disabled={isEditMode}
+                  />
+                </div>
+                {isEditMode && (
+                  <div className={`${styles.approvalRow} ${styles.fieldMt}`}>
+                    <button
+                      type="button"
+                      className={`${styles.toggle} ${availableForBooking ? styles.toggleOn : ''}`}
+                      onClick={() => setAvailableForBooking((v) => !v)}
+                      role="switch"
+                      aria-checked={availableForBooking}
+                    />
+                    <span className={styles.approvalLabel}>
+                      {availableForBooking ? 'Available for booking' : 'Unavailable for booking'}
+                    </span>
+                  </div>
+                )}
+              </>
             )}
           </div>
 

--- a/components/equipment/EquipmentList.module.css
+++ b/components/equipment/EquipmentList.module.css
@@ -250,6 +250,11 @@
   gap: 12px;
 }
 
+/* Indent quantity rows to align with unit group headers (chevron 16px + gap 12px) */
+.rowLeftQty {
+  padding-left: 28px;
+}
+
 .name {
   font-size: var(--font-body);
   font-weight: 700;

--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useEquipment } from '@/hooks/useEquipment'
-import { deactivateEquipment, toggleEquipmentAvailability } from '@/actions/equipment'
 import EquipmentEmpty from './EquipmentEmpty'
 import EquipmentEditModal from './EquipmentEditModal'
 import type { Equipment, EquipmentStatus, Role } from '@/types'
@@ -59,10 +58,6 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
   const [unifiedModalOpen, setUnifiedModalOpen] = useState(openOnMount)
   const [unifiedModalEquipment, setUnifiedModalEquipment] = useState<Equipment | undefined>(undefined)
 
-  const [deactivatingId, setDeactivatingId] = useState<string | null>(null)
-  const [actionError, setActionError] = useState<string | null>(null)
-  const [togglingAvailabilityId, setTogglingAvailabilityId] = useState<string | null>(null)
-
   function openAddModal() {
     setUnifiedModalEquipment(undefined)
     setUnifiedModalOpen(true)
@@ -71,25 +66,6 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
   function openEditModal(item: Equipment) {
     setUnifiedModalEquipment(item)
     setUnifiedModalOpen(true)
-  }
-
-  async function handleDeactivate(item: Equipment) {
-    if (!confirm(`Delete "${item.name}"? It will no longer appear in the equipment list.`)) return
-    setDeactivatingId(item.id)
-    setActionError(null)
-    const result = await deactivateEquipment(item.id)
-    setDeactivatingId(null)
-    if ('error' in result) setActionError(result.error)
-  }
-
-  async function handleToggleAvailability(item: Equipment) {
-    setTogglingAvailabilityId(item.id)
-    setActionError(null)
-    const result = await toggleEquipmentAvailability(item.id, !item.availableForBooking)
-    setTogglingAvailabilityId(null)
-    if (result.error) {
-      setActionError(result.error)
-    }
   }
 
   if (error) {
@@ -124,12 +100,6 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
         </div>
       )}
 
-      {actionError && (
-        <div className={styles.actionError}>
-          <p>{actionError}</p>
-        </div>
-      )}
-
       {equipment.length === 0 ? (
         <EquipmentEmpty role={role} onAddClick={openAddModal} />
       ) : (
@@ -152,7 +122,7 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
                 {/* Quantity items render flat */}
                 {quantityItems.map((item) => (
                   <div key={item.id} className={styles.row}>
-                    <div className={styles.rowLeft}>
+                    <div className={`${styles.rowLeft} ${styles.rowLeftQty}`}>
                       <span className={styles.name}>{item.name}</span>
                       {item.trackingType === 'quantity' && (
                         <>
@@ -169,28 +139,10 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
                     {role === 'admin' && (
                       <div className={styles.rowActions}>
                         <button
-                          className={item.availableForBooking ? styles.availabilityBtnAvailable : styles.availabilityBtnUnavailable}
-                          onClick={() => handleToggleAvailability(item)}
-                          disabled={togglingAvailabilityId === item.id}
-                        >
-                          {togglingAvailabilityId === item.id
-                            ? '...'
-                            : item.availableForBooking
-                              ? 'Available'
-                              : 'Unavailable'}
-                        </button>
-                        <button
                           className={styles.editBtn}
                           onClick={() => openEditModal(item)}
                         >
                           Edit
-                        </button>
-                        <button
-                          className={styles.deactivateBtn}
-                          onClick={() => handleDeactivate(item)}
-                          disabled={deactivatingId === item.id}
-                        >
-                          {deactivatingId === item.id ? 'Deleting...' : 'Delete'}
                         </button>
                       </div>
                     )}


### PR DESCRIPTION
Closes #171

## Summary
- Removed availability toggle and Delete button from quantity item list rows — only Edit remains (matches unit row behavior)
- Added availability toggle to the Edit modal's quantity section (edit mode only), saved via `updateEquipmentWithUnits`
- Indented quantity row text by 28px (chevron 16px + gap 12px) so name aligns with unit group headers

## Files changed
- `components/equipment/EquipmentList.tsx`
- `components/equipment/EquipmentList.module.css`
- `components/equipment/EquipmentEditModal.tsx`
- `actions/equipment.ts`