### PR TITLE
feat: add timezone selection to company signup flow (#173)

### DIFF
--- a/actions/auth.ts
+++ b/actions/auth.ts
@@ -6,6 +6,7 @@ import { FieldValue } from 'firebase-admin/firestore'
 import { adminAuth, adminDb } from '@/lib/firebase-admin'
 import { getVerifiedSession } from '@/lib/dal'
 import { PLAN_LIMITS } from '@/lib/subscription'
+import { DEFAULT_COMPANY_PREFERENCES } from '@/constants/company'
 
 const DEFAULT_CATEGORIES = ['Camera', 'Lenses', 'Audio', 'Lighting', 'Grip', 'Accessories']
 
@@ -45,6 +46,11 @@ export async function createSession(idToken: string): Promise<void> {
   }
 }
 
+function isValidTimezone(tz: string): boolean {
+  try { new Intl.DateTimeFormat(undefined, { timeZone: tz }); return true }
+  catch { return false }
+}
+
 /**
  * Creates a company for a newly registered user — server-side, no CORS issues.
  * Sets custom claims (activeCompanyId, role) on the Auth user.
@@ -62,6 +68,7 @@ export async function setupNewCompany(
   idToken: string,
   companyName: string,
   userName: string,
+  timezone = 'UTC',
 ): Promise<void> {
   let uid: string
   let email: string
@@ -72,6 +79,8 @@ export async function setupNewCompany(
   } catch {
     throw new Error('Invalid token')
   }
+
+  const safeTimezone = isValidTimezone(timezone) ? timezone : 'UTC'
 
   // Idempotency: if the user already has a membership, the account exists.
   const membershipCol = adminDb.collection(`users/${uid}/memberships`)
@@ -93,6 +102,7 @@ export async function setupNewCompany(
     createdBy:        uid,
     stripeCustomerId: '',
     hadTrial:         false,
+    preferences:      { ...DEFAULT_COMPANY_PREFERENCES, timezone: safeTimezone },
     subscription: {
       status:            'trialing',
       plan:              'starter',

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -8,6 +8,7 @@ import { getFunctions, httpsCallable } from 'firebase/functions'
 import { doc, getDoc } from 'firebase/firestore'
 import { auth, db } from '@/lib/firebase'
 import { setupNewCompany, createSession } from '@/actions/auth'
+import { TIMEZONE_OPTIONS } from '@/constants/company'
 import styles from './Auth.module.css'
 
 const MIN_PASSWORD_LENGTH = 8
@@ -36,6 +37,15 @@ export default function SignupForm() {
   const [inviteError,      setInviteError]      = useState<string | null>(null)
   const [resolvedToken,    setResolvedToken]    = useState<string | null>(inviteToken)
   const [emailLocked,      setEmailLocked]      = useState(inviteToken !== null)
+
+  const [timezone, setTimezone] = useState(() => {
+    try {
+      const detected = Intl.DateTimeFormat().resolvedOptions().timeZone
+      return TIMEZONE_OPTIONS.some(o => o.value === detected) ? detected : 'UTC'
+    } catch {
+      return 'UTC'
+    }
+  })
 
   const [companyName, setCompanyName] = useState('')
   const [userName,    setUserName]    = useState('')
@@ -181,7 +191,7 @@ export default function SignupForm() {
     // ── Standard path: create company + session ────────────────────────────
     try {
       const idToken = await credential.user.getIdToken()
-      await setupNewCompany(idToken, trimmedCompany, trimmedName)
+      await setupNewCompany(idToken, trimmedCompany, trimmedName, timezone)
     } catch (err) {
       await credential.user.delete().catch(() => {/* best-effort */})
 
@@ -344,6 +354,23 @@ export default function SignupForm() {
                 required
                 disabled={loading}
               />
+            </div>
+          )}
+
+          {!(mode === 'invite') && (
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="timezone">Timezone</label>
+              <select
+                id="timezone"
+                className={styles.input}
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                disabled={loading}
+              >
+                {TIMEZONE_OPTIONS.map(({ label, value }) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- Adds timezone select dropdown to the company creation signup form
- Auto-detects the user's browser timezone and pre-selects it if it exists in TIMEZONE_OPTIONS
- `setupNewCompany()` now accepts timezone, validates it server-side, and saves `preferences` (with the correct timezone) on the company document at creation time
- Invite flow is unaffected — the field only appears in the 'create' mode

## Test plan
- [ ] Go to /signup → "Create a new company" → verify timezone field appears pre-populated with your local timezone
- [ ] Create an account and verify Firestore `companies/{id}.preferences.timezone` is set correctly
- [ ] Go to Settings > Preferences and confirm the selected timezone is shown
- [ ] Go through the invite flow and confirm no timezone field appears

Closes #173