### PR TITLE
Fix week view: show full 24h day, scroll to 07:00 by default

### DIFF
--- a/components/bookings/BookingWeekView.module.css
+++ b/components/bookings/BookingWeekView.module.css
@@ -154,7 +154,6 @@
 .dayCol {
   border-right: 1px solid #1a1a1a;
   position: relative;
-  height: 720px;
 }
 
 .dayColWeekend {

--- a/components/bookings/BookingWeekView.tsx
+++ b/components/bookings/BookingWeekView.tsx
@@ -11,11 +11,11 @@ import styles from './BookingWeekView.module.css'
 // Time grid constants
 // ---------------------------------------------------------------------------
 
-const START_HOUR = 7
-const END_HOUR   = 22
-const HOURS      = END_HOUR - START_HOUR  // 15
+const START_HOUR = 0
+const END_HOUR   = 24
+const HOURS      = END_HOUR - START_HOUR  // 24
 const CELL_H     = 48
-const TOTAL_H    = HOURS * CELL_H         // 720px
+const TOTAL_H    = HOURS * CELL_H         // 1152px
 
 function timeToTop(time: string | null | undefined): number {
   if (!time) return 0
@@ -185,13 +185,16 @@ export default function BookingWeekView({
 
   const dateInputRef = useRef<HTMLInputElement>(null)
 
-  // Auto-scroll to current time
+  // Auto-scroll to current time (or 07:00 for non-current weeks)
   const calWrapRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    if (!days.includes(today)) return
-    const now     = new Date()
-    const lineTop = ((now.getHours() - START_HOUR) + now.getMinutes() / 60) * CELL_H
-    calWrapRef.current?.scrollTo({ top: Math.max(0, lineTop - 100) })
+    if (days.includes(today)) {
+      const now     = new Date()
+      const lineTop = (now.getHours() + now.getMinutes() / 60) * CELL_H
+      calWrapRef.current?.scrollTo({ top: Math.max(0, lineTop - 100) })
+    } else {
+      calWrapRef.current?.scrollTo({ top: Math.max(0, 7 * CELL_H - 100) })
+    }
   }, [weekStart]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
@@ -249,6 +252,7 @@ export default function BookingWeekView({
             <div
               key={day}
               className={`${styles.dayCol} ${isWeekend(day) ? styles.dayColWeekend : ''}`}
+            style={{ height: TOTAL_H }}
             >
               {Array.from({ length: HOURS }, (_, i) => (
                 <div key={i} className={styles.hourCell}>


### PR DESCRIPTION
## Summary
- Expands time grid from 07:00–22:00 to 00:00–24:00 so the entire day is reachable by scrolling
- Default scroll position is 07:00 for non-current weeks, current time for current week
- Day column height is now driven by the JS constant `TOTAL_H` (1152px) via inline style instead of hardcoded CSS

## Test plan
- [ ] Week view renders hours 00:00–23:00
- [ ] View scrolls to ~07:00 on load for non-current weeks
- [ ] View scrolls to current time on load for current week
- [ ] Booking blocks appear at correct vertical positions
- [ ] Current time line (yellow) shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)