### PR TITLE
fix: iOS date picker in booking views

### DIFF
--- a/components/bookings/Booking4WeekView.tsx
+++ b/components/bookings/Booking4WeekView.tsx
@@ -125,7 +125,10 @@ export default function Booking4WeekView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevPeriod())}>←</button>
-        <button className={styles.periodLabel} onClick={() => dateInputRef.current?.showPicker()}>
+        <button className={styles.periodLabel} onClick={() => {
+          try { dateInputRef.current?.showPicker() }
+          catch { dateInputRef.current?.focus() }
+        }}>
           {formatPeriodLabel(periodStart, endDate)}
         </button>
         <input

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -207,7 +207,8 @@ export default function BookingList({
                 onClick={() => {
                   if (datePickerRef.current) {
                     datePickerRef.current.value = dateStr
-                    datePickerRef.current.showPicker()
+                    try { datePickerRef.current.showPicker() }
+                    catch { datePickerRef.current.focus() }
                   }
                 }}
               >

--- a/components/bookings/BookingMonthView.tsx
+++ b/components/bookings/BookingMonthView.tsx
@@ -134,7 +134,10 @@ export default function BookingMonthView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevYear, prevMonth)}>←</button>
-        <button className={styles.monthLabel} onClick={() => monthInputRef.current?.showPicker()}>
+        <button className={styles.monthLabel} onClick={() => {
+          try { monthInputRef.current?.showPicker() }
+          catch { monthInputRef.current?.focus() }
+        }}>
           {formatMonthYear(year, month)}
         </button>
         <input

--- a/components/bookings/BookingWeekView.tsx
+++ b/components/bookings/BookingWeekView.tsx
@@ -202,7 +202,10 @@ export default function BookingWeekView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevWeek.week, prevWeek.year)}>←</button>
-        <button className={styles.weekLabel} onClick={() => dateInputRef.current?.showPicker()}>
+        <button className={styles.weekLabel} onClick={() => {
+          try { dateInputRef.current?.showPicker() }
+          catch { dateInputRef.current?.focus() }
+        }}>
           W.{String(weekNumber).padStart(2, '0')} — {formatMonthYear(weekStart)}
         </button>
         <input


### PR DESCRIPTION
## Summary

- `showPicker()` throws a `NotSupportedError` on iOS Safari — the date picker never opened when tapping date labels in any booking view
- Added `try/catch` with `.focus()` fallback in all 4 booking views (`BookingList`, `BookingWeekView`, `BookingMonthView`, `Booking4WeekView`)
- `focus()` on a date input natively opens the iOS Safari date wheel

## Test plan

- [ ] iOS Safari: tap date label in list, week, month, and 4-week view — date picker should open
- [ ] Android Chrome: same as above — `showPicker()` path used, behavior unchanged
- [ ] Desktop: same as above — behavior unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)