### PR TITLE
fix: iOS date picker overlay

### DIFF
--- a/components/bookings/Booking4WeekView.module.css
+++ b/components/bookings/Booking4WeekView.module.css
@@ -47,12 +47,25 @@
   padding: 0;
 }
 
-.hiddenDateInput {
+.periodLabelWrap {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.overlayDateInput {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
-  pointer-events: none;
-  width: 0;
-  height: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .todayBtn {

--- a/components/bookings/Booking4WeekView.tsx
+++ b/components/bookings/Booking4WeekView.tsx
@@ -125,20 +125,17 @@ export default function Booking4WeekView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevPeriod())}>←</button>
-        <button className={styles.periodLabel} onClick={() => {
-          try { dateInputRef.current?.showPicker() }
-          catch { dateInputRef.current?.focus() }
-        }}>
-          {formatPeriodLabel(periodStart, endDate)}
-        </button>
-        <input
-          ref={dateInputRef}
-          type="date"
-          onChange={(e) => {
-            if (e.target.value) navigate(toDateString(getMondayOf(e.target.value)))
-          }}
-          className={styles.hiddenDateInput}
-        />
+        <label className={styles.periodLabelWrap}>
+          <span className={styles.periodLabel}>{formatPeriodLabel(periodStart, endDate)}</span>
+          <input
+            ref={dateInputRef}
+            type="date"
+            onChange={(e) => {
+              if (e.target.value) navigate(toDateString(getMondayOf(e.target.value)))
+            }}
+            className={styles.overlayDateInput}
+          />
+        </label>
         <button className={styles.navBtn} onClick={() => navigate(nextPeriod())}>→</button>
         <button className={styles.todayBtn} onClick={goToToday}>Today</button>
       </div>

--- a/components/bookings/BookingList.module.css
+++ b/components/bookings/BookingList.module.css
@@ -254,10 +254,23 @@
   background: var(--secondary);
 }
 
-.hiddenDateInput {
+.dateLabelWrap {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.overlayDateInput {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
-  pointer-events: none;
-  width: 0;
-  height: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
 }

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo } from 'react'
 import Link from 'next/link'
 import { useBookings } from '@/hooks/useBookings'
 import type { Booking, Role, UserProfile } from '@/types'
@@ -87,8 +87,6 @@ export default function BookingList({
   initialBookings,
   userProfiles,
 }: BookingListProps) {
-  const datePickerRef = useRef<HTMLInputElement>(null)
-
   const [showCancelled, setShowCancelled] = useState(false)
   const [showOnlyMine, setShowOnlyMine] = useState(false)
 
@@ -183,17 +181,6 @@ export default function BookingList({
       )}
 
       {/* Date groups */}
-      <input
-        ref={datePickerRef}
-        type="date"
-        onChange={(e) => {
-          if (!e.target.value) return
-          const target = e.target.value
-          const nearest = [...sortedDates].reverse().find((d) => d >= target) ?? sortedDates[0]
-          if (nearest) document.getElementById(`group-${nearest}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        }}
-        className={styles.hiddenDateInput}
-      />
       {sortedDates.map((dateStr) => {
         const dateBookings = grouped.get(dateStr) ?? []
         const label = formatDateLabel(dateStr, today, tomorrow)
@@ -202,18 +189,22 @@ export default function BookingList({
         return (
           <div key={dateStr} id={`group-${dateStr}`} className={styles.group}>
             <div className={styles.groupHeader}>
-              <button
-                className={`${styles.dateLabel} ${isToday ? styles.dateLabelToday : ''}`}
-                onClick={() => {
-                  if (datePickerRef.current) {
-                    datePickerRef.current.value = dateStr
-                    try { datePickerRef.current.showPicker() }
-                    catch { datePickerRef.current.focus() }
-                  }
-                }}
-              >
-                {label.toUpperCase()}
-              </button>
+              <label className={styles.dateLabelWrap}>
+                <span className={`${styles.dateLabel} ${isToday ? styles.dateLabelToday : ''}`}>
+                  {label.toUpperCase()}
+                </span>
+                <input
+                  type="date"
+                  defaultValue={dateStr}
+                  onChange={(e) => {
+                    if (!e.target.value) return
+                    const target = e.target.value
+                    const nearest = [...sortedDates].reverse().find((d) => d >= target) ?? sortedDates[0]
+                    if (nearest) document.getElementById(`group-${nearest}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                  }}
+                  className={styles.overlayDateInput}
+                />
+              </label>
               <div className={styles.groupRule} />
             </div>
             <div className={styles.bookingCards}>

--- a/components/bookings/BookingMonthView.module.css
+++ b/components/bookings/BookingMonthView.module.css
@@ -47,12 +47,25 @@
   padding: 0;
 }
 
-.hiddenDateInput {
+.monthLabelWrap {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.overlayDateInput {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
-  pointer-events: none;
-  width: 0;
-  height: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .todayBtn {

--- a/components/bookings/BookingMonthView.tsx
+++ b/components/bookings/BookingMonthView.tsx
@@ -134,22 +134,19 @@ export default function BookingMonthView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevYear, prevMonth)}>←</button>
-        <button className={styles.monthLabel} onClick={() => {
-          try { monthInputRef.current?.showPicker() }
-          catch { monthInputRef.current?.focus() }
-        }}>
-          {formatMonthYear(year, month)}
-        </button>
-        <input
-          ref={monthInputRef}
-          type="month"
-          value={`${year}-${String(month).padStart(2, '0')}`}
-          onChange={(e) => {
-            const [y, m] = e.target.value.split('-').map(Number)
-            if (y && m) navigate(y, m)
-          }}
-          className={styles.hiddenDateInput}
-        />
+        <label className={styles.monthLabelWrap}>
+          <span className={styles.monthLabel}>{formatMonthYear(year, month)}</span>
+          <input
+            ref={monthInputRef}
+            type="month"
+            value={`${year}-${String(month).padStart(2, '0')}`}
+            onChange={(e) => {
+              const [y, m] = e.target.value.split('-').map(Number)
+              if (y && m) navigate(y, m)
+            }}
+            className={styles.overlayDateInput}
+          />
+        </label>
         <button className={styles.navBtn} onClick={() => navigate(nextYear, nextMonth)}>→</button>
         <button
           className={styles.todayBtn}

--- a/components/bookings/BookingWeekView.module.css
+++ b/components/bookings/BookingWeekView.module.css
@@ -257,10 +257,23 @@
   border-color: var(--accent);
 }
 
-.hiddenDateInput {
+.weekLabelWrap {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+}
+
+.overlayDateInput {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   opacity: 0;
-  pointer-events: none;
-  width: 0;
-  height: 0;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
 }

--- a/components/bookings/BookingWeekView.tsx
+++ b/components/bookings/BookingWeekView.tsx
@@ -202,22 +202,21 @@ export default function BookingWeekView({
       {/* Nav bar */}
       <div className={styles.navBar}>
         <button className={styles.navBtn} onClick={() => navigate(prevWeek.week, prevWeek.year)}>←</button>
-        <button className={styles.weekLabel} onClick={() => {
-          try { dateInputRef.current?.showPicker() }
-          catch { dateInputRef.current?.focus() }
-        }}>
-          W.{String(weekNumber).padStart(2, '0')} — {formatMonthYear(weekStart)}
-        </button>
-        <input
-          ref={dateInputRef}
-          type="date"
-          onChange={(e) => {
-            if (!e.target.value) return
-            const d = new Date(e.target.value + 'T00:00:00')
-            navigate(getISOWeek(d), d.getFullYear())
-          }}
-          className={styles.hiddenDateInput}
-        />
+        <label className={styles.weekLabelWrap}>
+          <span className={styles.weekLabel}>
+            W.{String(weekNumber).padStart(2, '0')} — {formatMonthYear(weekStart)}
+          </span>
+          <input
+            ref={dateInputRef}
+            type="date"
+            onChange={(e) => {
+              if (!e.target.value) return
+              const d = new Date(e.target.value + 'T00:00:00')
+              navigate(getISOWeek(d), d.getFullYear())
+            }}
+            className={styles.overlayDateInput}
+          />
+        </label>
         <button className={styles.navBtn} onClick={() => navigate(nextWeek.week, nextWeek.year)}>→</button>
         <button
           className={styles.todayBtn}


### PR DESCRIPTION
## Summary
The previous showPicker/focus approach did not work on iOS Safari — only direct user taps on the date input element itself trigger the native picker. By overlaying the input as a transparent click target on top of the visible label, we ensure iOS users can tap the label and activate the picker.

## Changes
- Modified 4 component files and their CSS modules:
  - BookingList.tsx + .module.css
  - BookingWeekView.tsx + .module.css
  - BookingMonthView.tsx + .module.css
  - Booking4WeekView.tsx + .module.css

## Test plan
- Test on iOS Safari by tapping date range pickers in all booking views
- Verify native date picker opens when label is tapped
- Confirm desktop behavior (input focus) still works as expected

🤖 Generated with Claude Code