### PR TITLE
Add alpha/beta Firebase project aliases and per-backend apphosting config

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,8 @@
+{
+  "projects": {
+    "default":    "allocate-e0735",
+    "production": "allocate-e0735",
+    "alpha":      "allocate-alpha",
+    "beta":       "allocate-beta"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 # Firebase
-.firebaserc
 .firebase/
 firebase-debug.log
 firestore-debug.log

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,5 +1,9 @@
 # Firebase App Hosting configuration
 # Docs: https://firebase.google.com/docs/app-hosting/configure
+#
+# NEXT_PUBLIC_FIREBASE_* and NEXT_PUBLIC_APP_URL are NOT hardcoded here —
+# they differ per environment (alpha/beta/prod) and are set per-backend via:
+#   firebase --project <id> apphosting:config:set KEY="value"
 
 runConfig:
   minInstances: 0
@@ -9,49 +13,41 @@ runConfig:
   memoryMiB: 512
 
 env:
-  # Public Firebase client config — needed at build time so it ends up in the client bundle.
+  # Public Firebase client config — set per-backend, needed at build time.
   - variable: NEXT_PUBLIC_FIREBASE_API_KEY
-    value: "AIzaSyDlmC62B2RS-zO_YseqbcOs4gpzKaiVd-A"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-    value: "allocate-e0735.firebaseapp.com"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-    value: "allocate-e0735"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
-    value: "allocate-e0735.firebasestorage.app"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
-    value: "5366151572"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_APP_ID
-    value: "1:5366151572:web:f63b276838880215053781"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
-    value: "G-02WW3DDDPD"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_APP_URL
-    value: "https://allocate--allocate-e0735.europe-west4.hosted.app"
     availability:
       - BUILD
       - RUNTIME
 
-  # Stripe price IDs — non-secret, runtime only. Replace placeholders with real price IDs from Stripe Dashboard before enabling checkout.
+  # Stripe price IDs — non-secret, runtime only.
   - variable: STRIPE_PRICE_STARTER_MONTHLY
     value: "price_1Q0r0X06TtFrNVu39VXac7MQ"
     availability:


### PR DESCRIPTION
## Summary
- Adds `.firebaserc` with `production`, `alpha`, and `beta` project aliases so `firebase use alpha/beta/production` works for all team members
- Removes `.firebaserc` from `.gitignore` so aliases are shared
- Removes hardcoded `NEXT_PUBLIC_FIREBASE_*` and `NEXT_PUBLIC_APP_URL` values from `apphosting.yaml` — these are now set per-backend in Firebase Console to support the `dev → alpha → beta → main` promotion flow

## What was set up outside this PR
- Firebase projects `allocate-alpha` and `allocate-beta` created (eur3 Firestore, europe-west4 App Hosting)
- Firestore rules and indexes deployed to both
- All 15 Cloud Functions deployed to both
- Secrets (`FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON`, `STRIPE_SECRET_KEY`) set in Secret Manager for both
- Git branches `alpha` and `beta` created and pushed

## Remaining manual step
- `STRIPE_WEBHOOK_SECRET` needs to be set per environment in Stripe Dashboard once backends are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)