### PR TITLE
feat: notifications panel + support/feedback modal

### DIFF
--- a/actions/submitFeedback.ts
+++ b/actions/submitFeedback.ts
@@ -1,0 +1,56 @@
+'use server'
+
+import { getVerifiedSession } from '@/lib/dal'
+import { adminDb } from '@/lib/firebase-admin'
+import { FieldValue } from 'firebase-admin/firestore'
+import type { FeedbackType, FeedbackStatus, FeedbackPriority } from '@/types/operator'
+
+export type SubmitFeedbackResult = { ticketId: string } | { error: string }
+
+export async function submitFeedback(data: {
+  type: FeedbackType
+  title: string
+  description: string
+}): Promise<SubmitFeedbackResult> {
+  try {
+    const session = await getVerifiedSession()
+    const { uid, activeCompanyId } = session
+
+    // Validate
+    if (!data.title.trim() || data.title.trim().length > 200) return { error: 'Invalid title' }
+    if (!data.description.trim() || data.description.trim().length > 2000) return { error: 'Invalid description' }
+
+    // Fetch user name + company name in parallel
+    const [userSnap, companySnap] = await Promise.all([
+      adminDb.doc(`users/${uid}`).get(),
+      adminDb.doc(`companies/${activeCompanyId}`).get(),
+    ])
+    const userName = (userSnap.data()?.name as string) ?? session.email
+    const companyName = (companySnap.data()?.name as string) ?? activeCompanyId
+
+    // Generate human-readable ticket ID
+    const prefix = data.type === 'bug_report' ? 'BUG' : data.type === 'feature_request' ? 'FEA' : 'SUP'
+    const ticketId = `${prefix}-${String(Math.floor(Math.random() * 9000) + 1000)}`
+
+    await adminDb.collection('operatorFeedback').doc(ticketId).set({
+      type: data.type,
+      title: data.title.trim(),
+      description: data.description.trim(),
+      submittedAt: FieldValue.serverTimestamp(),
+      submittedBy: uid,
+      companyId: activeCompanyId,
+      companyName,
+      userName,
+      status: 'open' as FeedbackStatus,
+      priority: 'medium' as FeedbackPriority,
+    })
+
+    return { ticketId }
+  } catch (err) {
+    const digest = (err as { digest?: string }).digest ?? ''
+    const msg = err instanceof Error ? err.message : ''
+    if (digest.startsWith('NEXT_REDIRECT') || msg.startsWith('REDIRECT:')) throw err
+    console.error('[submitFeedback] error', err)
+    return { error: 'Failed to submit. Please try again.' }
+  }
+}

--- a/app/operator/feedback/page.tsx
+++ b/app/operator/feedback/page.tsx
@@ -27,6 +27,7 @@ export default async function FeedbackPage({
       submittedBy: d.submittedBy,
       companyId: d.companyId ?? '',
       companyName: d.companyName ?? '',
+      userName: d.userName ?? '',
       status: d.status,
       priority: d.priority,
     }

--- a/components/nav/MobileMenu.module.css
+++ b/components/nav/MobileMenu.module.css
@@ -169,3 +169,18 @@
 .ctaBtn:hover {
   background: var(--secondary);
 }
+
+.unreadBadge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  background: var(--accent);
+  color: var(--black);
+  font-size: 0.625rem;
+  font-weight: 800;
+  border-radius: 10px;
+}

--- a/components/nav/MobileMenu.tsx
+++ b/components/nav/MobileMenu.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import type { Role } from '@/types'
+import { useSupportContext } from '@/lib/support-context'
 import styles from './MobileMenu.module.css'
 
 // ── Top-level nav ─────────────────────────────────────────────────────────────
@@ -46,6 +47,7 @@ interface MobileMenuProps {
 export function MobileMenu({ role }: MobileMenuProps) {
   const [open, setOpen] = useState(false)
   const pathname = usePathname()
+  const { openHelp, openNotifications, unreadCount } = useSupportContext()
 
   // Auto-close when the route changes.
   // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -155,6 +157,28 @@ export function MobileMenu({ role }: MobileMenuProps) {
               ))}
             </div>
           )}
+
+          {/* More */}
+          <div className={styles.section}>
+            <p className={styles.sectionLabel}>More</p>
+            <button
+              className={styles.navItem}
+              onClick={() => { openNotifications(); setOpen(false) }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>notifications</span>
+              Notifications
+              {unreadCount > 0 && (
+                <span className={styles.unreadBadge}>{unreadCount}</span>
+              )}
+            </button>
+            <button
+              className={styles.navItem}
+              onClick={() => { openHelp(); setOpen(false) }}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>help</span>
+              Help &amp; feedback
+            </button>
+          </div>
         </div>
 
         {/* Bottom CTA */}

--- a/components/nav/PrimaryNav.module.css
+++ b/components/nav/PrimaryNav.module.css
@@ -78,6 +78,51 @@
   gap: 24px;
 }
 
+.iconGroup {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.iconBtn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  color: rgba(240, 237, 232, 0.5);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s, background 0.1s;
+}
+
+.iconBtn:hover {
+  color: var(--white);
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.iconBtnActive {
+  color: var(--white);
+  border-color: rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.unreadDot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--black);
+  pointer-events: none;
+}
+
 @media (max-width: 768px) {
   .links {
     display: none;

--- a/components/nav/PrimaryNav.tsx
+++ b/components/nav/PrimaryNav.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import type { Role } from '@/types'
+import { useSupportContext } from '@/lib/support-context'
 import styles from './PrimaryNav.module.css'
 
 interface PrimaryNavProps {
@@ -16,6 +17,7 @@ interface PrimaryNavProps {
 export default function PrimaryNav({ role }: PrimaryNavProps) {
   const pathname = usePathname()
   const isActive = (path: string) => pathname.startsWith(path)
+  const { openHelp, openNotifications, notificationsOpen, unreadCount } = useSupportContext()
 
   return (
     <nav className={styles.nav}>
@@ -44,6 +46,26 @@ export default function PrimaryNav({ role }: PrimaryNavProps) {
         </div>
 
         <div className={styles.actions}>
+          <div className={styles.iconGroup}>
+            <button
+              className={`${styles.iconBtn} ${notificationsOpen ? styles.iconBtnActive : ''}`}
+              onClick={openNotifications}
+              aria-label="Notifications"
+              title="Notifications"
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>notifications</span>
+              {unreadCount > 0 && <span className={styles.unreadDot} aria-hidden="true" />}
+            </button>
+            <button
+              className={styles.iconBtn}
+              onClick={() => openHelp()}
+              aria-label="Help & feedback"
+              title="Help & feedback  (Shift+?)"
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>help</span>
+            </button>
+          </div>
+
           {isActive('/equipment') && role === 'admin' ? (
             <Link href="/equipment?add=1" className={styles.newBookingBtn}>
               NEW EQUIPMENT

--- a/components/support/NotificationsPanel.module.css
+++ b/components/support/NotificationsPanel.module.css
@@ -1,0 +1,116 @@
+.panel {
+  position: fixed;
+  top: 64px;
+  right: 24px;
+  width: 300px;
+  background: var(--surface-container-low);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  z-index: 55;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-8px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.panelOpen {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(71, 71, 71, 0.2);
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--white);
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: rgba(240, 237, 232, 0.4);
+  cursor: pointer;
+  padding: 2px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  transition: color 0.1s;
+}
+
+.closeBtn:hover {
+  color: var(--white);
+}
+
+.body {
+  flex: 1;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.emptyIcon {
+  font-size: 32px;
+  color: var(--outline);
+}
+
+.emptyText {
+  font-size: 0.75rem;
+  color: var(--mid);
+  letter-spacing: 0.05em;
+}
+
+.footer {
+  padding: 12px 18px;
+  border-top: 1px solid rgba(71, 71, 71, 0.2);
+  flex-shrink: 0;
+}
+
+.footerLink {
+  background: none;
+  border: none;
+  color: rgba(240, 237, 232, 0.4);
+  cursor: pointer;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0;
+  transition: color 0.1s;
+}
+
+.footerLink:hover {
+  color: var(--white);
+}
+
+@media (max-width: 768px) {
+  .panel {
+    top: 56px;
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+}

--- a/components/support/NotificationsPanel.tsx
+++ b/components/support/NotificationsPanel.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useSupportContext } from '@/lib/support-context'
+import styles from './NotificationsPanel.module.css'
+
+export default function NotificationsPanel() {
+  const { notificationsOpen, closeNotifications } = useSupportContext()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!notificationsOpen) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        closeNotifications()
+      }
+    }
+    setTimeout(() => document.addEventListener('mousedown', onMouseDown), 0)
+    return () => document.removeEventListener('mousedown', onMouseDown)
+  }, [notificationsOpen, closeNotifications])
+
+  return (
+    <div
+      ref={panelRef}
+      className={`${styles.panel} ${notificationsOpen ? styles.panelOpen : ''}`}
+      role="dialog"
+      aria-label="Notifications"
+      aria-hidden={!notificationsOpen}
+    >
+      <div className={styles.header}>
+        <span className={styles.title}>Notifications</span>
+        <button className={styles.closeBtn} onClick={closeNotifications} aria-label="Close notifications">
+          <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>close</span>
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.emptyState}>
+          <span className={`material-symbols-outlined ${styles.emptyIcon}`}>notifications</span>
+          <p className={styles.emptyText}>You're all caught up</p>
+        </div>
+      </div>
+
+      <div className={styles.footer}>
+        <button className={styles.footerLink}>Notification settings</button>
+      </div>
+    </div>
+  )
+}

--- a/components/support/SupportModal.module.css
+++ b/components/support/SupportModal.module.css
@@ -1,0 +1,501 @@
+/* Backdrop */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+/* Modal container */
+.modal {
+  position: relative;
+  width: min(540px, 100%);
+  max-height: calc(100vh - 80px);
+  background: var(--surface-container-lowest);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: popIn 0.15s ease;
+}
+
+@keyframes popIn {
+  from { opacity: 0; transform: scale(0.98) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 22px;
+  border-bottom: 1px solid rgba(71, 71, 71, 0.2);
+  flex-shrink: 0;
+}
+
+.headerTitle {
+  font-size: 0.875rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  color: var(--white);
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: rgba(240, 237, 232, 0.4);
+  cursor: pointer;
+  padding: 2px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  transition: color 0.1s;
+}
+
+.closeBtn:hover {
+  color: var(--white);
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  border-bottom: 1px solid rgba(71, 71, 71, 0.2);
+  background: rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+}
+
+.tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 14px 10px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(240, 237, 232, 0.4);
+  background: none;
+  border: none;
+  border-right: 1px solid rgba(71, 71, 71, 0.2);
+  cursor: pointer;
+  position: relative;
+  transition: color 0.1s, background 0.1s;
+}
+
+.tab:last-child {
+  border-right: none;
+}
+
+.tab:hover {
+  color: var(--white);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tabActive {
+  color: var(--white);
+  background: var(--surface-container-lowest);
+}
+
+.tabActive::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--accent);
+}
+
+.tabNum {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.5625rem;
+  color: rgba(255, 255, 255, 0.2);
+  margin-left: 2px;
+}
+
+/* Body (scrollable) */
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px 22px 8px;
+}
+
+/* Lead text */
+.lead {
+  font-size: 0.8125rem;
+  color: var(--mid);
+  line-height: 1.6;
+  margin: 0 0 4px;
+}
+
+/* Form fields */
+.field {
+  display: block;
+  margin-top: 18px;
+}
+
+.fieldLabel {
+  display: block;
+  font-size: 0.5625rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mid);
+  margin-bottom: 6px;
+}
+
+.input,
+.select {
+  width: 100%;
+  background: var(--surface-container);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  color: var(--white);
+  padding: 10px 12px;
+  font-family: var(--font-sans), system-ui, sans-serif;
+  font-size: 0.875rem;
+  border-radius: 2px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.input:focus,
+.select:focus {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.textarea {
+  width: 100%;
+  background: var(--surface-container);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  color: var(--white);
+  padding: 10px 12px;
+  font-family: var(--font-sans), system-ui, sans-serif;
+  font-size: 0.875rem;
+  border-radius: 2px;
+  outline: none;
+  transition: border-color 0.15s;
+  min-height: 120px;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.textarea:focus {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.hint {
+  display: block;
+  margin-top: 4px;
+  font-size: 0.6875rem;
+  color: var(--mid);
+}
+
+/* Severity */
+.severity {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.sevBtn {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: none;
+  padding: 10px 10px;
+  cursor: pointer;
+  border-radius: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: left;
+  transition: border-color 0.1s, background 0.1s;
+}
+
+.sevBtn:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.sevBtnActive {
+  border-color: rgba(255, 255, 255, 0.5);
+  background: var(--surface-container);
+}
+
+.sevName {
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--white);
+}
+
+.sevDesc {
+  font-size: 0.6875rem;
+  color: var(--mid);
+  line-height: 1.4;
+}
+
+/* Row for 2-column layout */
+.row2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+/* Checkbox */
+.checkboxField {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 16px;
+  cursor: pointer;
+}
+
+.checkbox {
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--accent);
+}
+
+.checkboxLabel {
+  font-size: 0.75rem;
+  color: rgba(240, 237, 232, 0.6);
+  line-height: 1.5;
+}
+
+/* Feature pills */
+.pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.pill {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: none;
+  padding: 6px 10px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(240, 237, 232, 0.5);
+  cursor: pointer;
+  border-radius: 2px;
+  transition: border-color 0.1s, color 0.1s, background 0.1s;
+}
+
+.pill:hover {
+  border-color: rgba(255, 255, 255, 0.3);
+  color: var(--white);
+}
+
+.pillActive {
+  border-color: var(--white);
+  color: var(--black);
+  background: var(--white);
+}
+
+/* In-tab submit area */
+.tabActions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 18px;
+  margin-bottom: 10px;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 14px 22px;
+  border-top: 1px solid rgba(71, 71, 71, 0.2);
+  background: rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
+}
+
+.footerActions {
+  display: flex;
+  gap: 8px;
+}
+
+/* Buttons */
+.submitBtn {
+  background: var(--white);
+  color: var(--on-primary);
+  padding: 10px 20px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.1s;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: var(--secondary);
+}
+
+.submitBtnDisabled {
+  background: var(--surface-container);
+  color: rgba(255, 255, 255, 0.2);
+  cursor: not-allowed;
+}
+
+.ghostBtn {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(240, 237, 232, 0.6);
+  padding: 10px 16px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: border-color 0.1s, color 0.1s;
+}
+
+.ghostBtn:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--white);
+}
+
+.primaryBtn {
+  background: var(--white);
+  color: var(--on-primary);
+  padding: 10px 20px;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 0.1s;
+}
+
+.primaryBtn:hover {
+  background: var(--secondary);
+}
+
+/* Error message */
+.errorMsg {
+  font-size: 0.75rem;
+  color: var(--error);
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: rgba(204, 51, 51, 0.1);
+  border: 1px solid rgba(204, 51, 51, 0.2);
+  border-radius: 2px;
+}
+
+/* Loading state */
+.loadingState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+}
+
+.loadingText {
+  font-size: 0.75rem;
+  color: var(--mid);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+/* Success state */
+.success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 32px 24px;
+}
+
+.successIcon {
+  font-size: 48px;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.successTitle {
+  font-size: 1.25rem;
+  font-weight: 900;
+  letter-spacing: -0.01em;
+  text-transform: uppercase;
+  margin: 0 0 8px;
+  color: var(--white);
+}
+
+.successDesc {
+  font-size: 0.8125rem;
+  color: var(--mid);
+  line-height: 1.6;
+  max-width: 40ch;
+  margin: 0 0 16px;
+}
+
+.ticketBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  color: var(--mid);
+  border-radius: 2px;
+}
+
+/* Mobile: full-screen modal */
+@media (max-width: 768px) {
+  .backdrop {
+    padding: 0;
+    align-items: flex-start;
+  }
+
+  .modal {
+    width: 100%;
+    max-height: 100svh;
+    border-radius: 0;
+    border: none;
+    height: 100svh;
+  }
+
+  .tabs {
+    overflow-x: auto;
+  }
+
+  .tab {
+    flex: 0 0 auto;
+    padding: 14px 14px;
+  }
+
+  .severity {
+    grid-template-columns: 1fr;
+  }
+
+  .row2 {
+    grid-template-columns: 1fr;
+  }
+}

--- a/components/support/SupportModal.tsx
+++ b/components/support/SupportModal.tsx
@@ -1,0 +1,391 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useSupportContext } from '@/lib/support-context'
+import { useToast } from '@/lib/toast-context'
+import { submitFeedback } from '@/actions/submitFeedback'
+import { getRecentActions } from '@/lib/action-tracker'
+import styles from './SupportModal.module.css'
+
+// ── Bug form ────────────────────────────────────────────────────────────────
+
+const SEVERITIES = [
+  { key: 'low' as const, label: 'Low', desc: 'Cosmetic, easy workaround.' },
+  { key: 'medium' as const, label: 'Medium', desc: 'Annoying, but I can keep working.' },
+  { key: 'high' as const, label: 'High', desc: 'Blocking — cannot complete a task.' },
+]
+
+const AREAS = ['Bookings', 'Equipment', 'Settings', 'Calendar', 'Notifications', 'Login / Auth', 'Other']
+
+function BugForm({ onSubmit }: { onSubmit: (title: string, description: string) => void }) {
+  const [title, setTitle] = useState('')
+  const [steps, setSteps] = useState('')
+  const [severity, setSeverity] = useState<'low' | 'medium' | 'high' | null>(null)
+  const [area, setArea] = useState('Bookings')
+  const [includeDiag, setIncludeDiag] = useState(false)
+  const canSend = title.trim().length > 4 && steps.trim().length > 8 && severity !== null
+
+  const handleSubmit = () => {
+    let diagBlock = ''
+    if (includeDiag) {
+      const ua = navigator.userAgent
+      const url = window.location.href
+      const actions = getRecentActions()
+      diagBlock = `\n\n--- Diagnostics ---\nBrowser: ${ua}\nURL: ${url}\n\nLast actions:\n${actions}\n--- End diagnostics ---`
+    }
+    const description = `Severity: ${severity}\nArea: ${area}\n\nSteps to reproduce:\n${steps}${diagBlock}`
+    onSubmit(title.trim(), description)
+  }
+
+  return (
+    <>
+      <p className={styles.lead}>Describe what happened, where in the app it occurred, and how we can reproduce it.</p>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Headline</span>
+        <input
+          className={styles.input}
+          type="text"
+          placeholder="A brief description of what isn't working"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          maxLength={200}
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>What happened?</span>
+        <textarea
+          className={styles.textarea}
+          placeholder={"1. Navigate to...\n2. Click on...\n3. ...\n\nExpected: ...\nActual: ..."}
+          value={steps}
+          onChange={e => setSteps(e.target.value)}
+          maxLength={2000}
+        />
+        <span className={styles.hint}>Include steps to reproduce, what you expected, and what happened instead.</span>
+      </label>
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>Severity</span>
+        <div className={styles.severity}>
+          {SEVERITIES.map(s => (
+            <button
+              key={s.key}
+              type="button"
+              className={`${styles.sevBtn} ${severity === s.key ? styles.sevBtnActive : ''}`}
+              onClick={() => setSeverity(s.key)}
+            >
+              <span className={styles.sevName}>{s.label}</span>
+              <span className={styles.sevDesc}>{s.desc}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.row2}>
+        <label className={styles.field}>
+          <span className={styles.fieldLabel}>Where in Allocate?</span>
+          <select className={styles.select} value={area} onChange={e => setArea(e.target.value)}>
+            {AREAS.map(a => <option key={a} value={a}>{a}</option>)}
+          </select>
+        </label>
+      </div>
+
+      <label className={styles.checkboxField}>
+        <input
+          type="checkbox"
+          checked={includeDiag}
+          onChange={e => setIncludeDiag(e.target.checked)}
+          className={styles.checkbox}
+        />
+        <span className={styles.checkboxLabel}>
+          Include diagnostics — browser, version, current URL, and last 50 actions.
+        </span>
+      </label>
+
+      <div className={styles.tabActions}>
+        <button
+          type="button"
+          className={`${styles.submitBtn} ${!canSend ? styles.submitBtnDisabled : ''}`}
+          disabled={!canSend}
+          onClick={handleSubmit}
+        >
+          Send report
+        </button>
+      </div>
+    </>
+  )
+}
+
+// ── Feature form ────────────────────────────────────────────────────────────
+
+const FEATURE_TAGS = ['Calendar', 'Equipment', 'Permissions', 'Mobile', 'Integrations', 'Reporting', 'Notifications']
+
+function FeatureForm({ onSubmit }: { onSubmit: (title: string, description: string) => void }) {
+  const [title, setTitle] = useState('')
+  const [why, setWhy] = useState('')
+  const [tags, setTags] = useState<Set<string>>(new Set())
+  const canSend = title.trim().length > 4 && why.trim().length > 8
+
+  const toggleTag = (tag: string) => {
+    setTags(prev => {
+      const next = new Set(prev)
+      next.has(tag) ? next.delete(tag) : next.add(tag)
+      return next
+    })
+  }
+
+  const handleSubmit = () => {
+    const tagLine = tags.size > 0 ? `\nArea: ${[...tags].join(', ')}\n\n` : '\n\n'
+    const description = `${tagLine}${why.trim()}`
+    onSubmit(title.trim(), description)
+  }
+
+  return (
+    <>
+      <p className={styles.lead}>Describe the change you'd like to see and the problem it would solve.</p>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>In one sentence</span>
+        <input
+          className={styles.input}
+          type="text"
+          placeholder="A brief description of the feature you have in mind"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          maxLength={200}
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>What problem does this solve?</span>
+        <textarea
+          className={styles.textarea}
+          placeholder={"Describe the situation where this would be useful and how it would help your workflow."}
+          value={why}
+          onChange={e => setWhy(e.target.value)}
+          maxLength={2000}
+        />
+      </label>
+
+      <div className={styles.field}>
+        <span className={styles.fieldLabel}>Area</span>
+        <div className={styles.pills}>
+          {FEATURE_TAGS.map(tag => (
+            <button
+              key={tag}
+              type="button"
+              className={`${styles.pill} ${tags.has(tag) ? styles.pillActive : ''}`}
+              onClick={() => toggleTag(tag)}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.tabActions}>
+        <button
+          type="button"
+          className={`${styles.submitBtn} ${!canSend ? styles.submitBtnDisabled : ''}`}
+          disabled={!canSend}
+          onClick={handleSubmit}
+        >
+          Submit request
+        </button>
+      </div>
+    </>
+  )
+}
+
+// ── Help form ────────────────────────────────────────────────────────────────
+
+function HelpForm({ onSubmit }: { onSubmit: (title: string, description: string) => void }) {
+  const [topic, setTopic] = useState('')
+  const [msg, setMsg] = useState('')
+  const canSend = topic.trim().length > 3 && msg.trim().length > 8
+
+  return (
+    <>
+      <p className={styles.lead}>Describe what you're trying to do or what's unclear and we'll get back to you.</p>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Subject</span>
+        <input
+          className={styles.input}
+          type="text"
+          placeholder="A brief description of what you need help with"
+          value={topic}
+          onChange={e => setTopic(e.target.value)}
+          maxLength={200}
+        />
+      </label>
+
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Message</span>
+        <textarea
+          className={styles.textarea}
+          placeholder="Describe your question or the situation in as much detail as you can."
+          value={msg}
+          onChange={e => setMsg(e.target.value)}
+          maxLength={2000}
+        />
+      </label>
+
+      <div className={styles.tabActions}>
+        <button
+          type="button"
+          className={`${styles.submitBtn} ${!canSend ? styles.submitBtnDisabled : ''}`}
+          disabled={!canSend}
+          onClick={() => onSubmit(topic.trim(), msg.trim())}
+        >
+          Send message
+        </button>
+      </div>
+    </>
+  )
+}
+
+// ── Main modal ──────────────────────────────────────────────────────────────
+
+export default function SupportModal() {
+  const { helpOpen, activeTab, closeHelp, openHelp } = useSupportContext()
+  const { showToast } = useToast()
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState<{ ticketId: string; kind: string } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset on tab change
+  const handleTabChange = useCallback((tab: Parameters<typeof openHelp>[0]) => {
+    setSubmitted(null)
+    setError(null)
+    openHelp(tab)
+  }, [openHelp])
+
+  const handleClose = useCallback(() => {
+    closeHelp()
+    setTimeout(() => { setSubmitted(null); setError(null) }, 200)
+  }, [closeHelp])
+
+  const handleSubmit = async (type: 'bug_report' | 'feature_request' | 'support', title: string, description: string) => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const result = await submitFeedback({ type, title, description })
+      if ('error' in result) {
+        setError(result.error)
+      } else {
+        const kindLabel = type === 'bug_report' ? 'Bug report' : type === 'feature_request' ? 'Feature request' : 'Message'
+        setSubmitted({ ticketId: result.ticketId, kind: kindLabel })
+        showToast('success', `${kindLabel} sent — ref ${result.ticketId}`, 4000)
+        setTimeout(() => handleClose(), 2200)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (!helpOpen) return null
+
+  return (
+    <div className={styles.backdrop} onClick={handleClose}>
+      <div
+        className={styles.modal}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Help & feedback"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className={styles.header}>
+          <span className={styles.headerTitle}>Help &amp; feedback</span>
+          <button className={styles.closeBtn} onClick={handleClose} aria-label="Close">
+            <span className="material-symbols-outlined" style={{ fontSize: '18px' }}>close</span>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        {!submitted && (
+          <div className={styles.tabs} role="tablist">
+            <button
+              role="tab"
+              aria-selected={activeTab === 'bug'}
+              className={`${styles.tab} ${activeTab === 'bug' ? styles.tabActive : ''}`}
+              onClick={() => handleTabChange('bug')}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '15px' }}>bug_report</span>
+              Bug report
+              <span className={styles.tabNum}>01</span>
+            </button>
+            <button
+              role="tab"
+              aria-selected={activeTab === 'feature'}
+              className={`${styles.tab} ${activeTab === 'feature' ? styles.tabActive : ''}`}
+              onClick={() => handleTabChange('feature')}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '15px' }}>lightbulb</span>
+              Feature request
+              <span className={styles.tabNum}>02</span>
+            </button>
+            <button
+              role="tab"
+              aria-selected={activeTab === 'help'}
+              className={`${styles.tab} ${activeTab === 'help' ? styles.tabActive : ''}`}
+              onClick={() => handleTabChange('help')}
+            >
+              <span className="material-symbols-outlined" style={{ fontSize: '15px' }}>support_agent</span>
+              Get help
+              <span className={styles.tabNum}>03</span>
+            </button>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className={styles.body}>
+          {submitted ? (
+            <div className={styles.success}>
+              <span className={`material-symbols-outlined ${styles.successIcon}`}>check_circle</span>
+              <h3 className={styles.successTitle}>{submitted.kind} sent</h3>
+              <p className={styles.successDesc}>
+                {activeTab === 'bug' && 'Thanks — we triage incoming reports within one business day.'}
+                {activeTab === 'feature' && 'Thanks for the suggestion. We review the request board every Friday.'}
+                {activeTab === 'help' && 'Our support team replies within a few hours during business days.'}
+              </p>
+              <div className={styles.ticketBadge}>
+                <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>confirmation_number</span>
+                {submitted.ticketId}
+              </div>
+            </div>
+          ) : submitting ? (
+            <div className={styles.loadingState}>
+              <p className={styles.loadingText}>Sending…</p>
+            </div>
+          ) : (
+            <>
+              {error && <p className={styles.errorMsg}>{error}</p>}
+              {activeTab === 'bug' && (
+                <BugForm onSubmit={(title, desc) => handleSubmit('bug_report', title, desc)} />
+              )}
+              {activeTab === 'feature' && (
+                <FeatureForm onSubmit={(title, desc) => handleSubmit('feature_request', title, desc)} />
+              )}
+              {activeTab === 'help' && (
+                <HelpForm onSubmit={(title, desc) => handleSubmit('support', title, desc)} />
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        {submitted && (
+          <div className={styles.footer}>
+            <div className={styles.footerActions}>
+              <button className={styles.ghostBtn} onClick={() => { setSubmitted(null); setError(null) }}>Send another</button>
+              <button className={styles.primaryBtn} onClick={handleClose}>Done</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/action-tracker.ts
+++ b/lib/action-tracker.ts
@@ -1,0 +1,14 @@
+'use client'
+
+const MAX = 50
+const actions: string[] = []
+
+export function trackAction(label: string) {
+  const ts = new Date().toISOString().slice(11, 19)
+  actions.push(`${ts} ${label}`)
+  if (actions.length > MAX) actions.shift()
+}
+
+export function getRecentActions(): string {
+  return actions.slice().reverse().join('\n') || '(none)'
+}

--- a/lib/providers.tsx
+++ b/lib/providers.tsx
@@ -3,12 +3,19 @@
 import { AuthProvider } from '@/lib/auth-context'
 import { ToastProvider } from '@/lib/toast-context'
 import { ToastContainer } from '@/components/ui/Toast'
+import { SupportProvider } from '@/lib/support-context'
+import SupportModal from '@/components/support/SupportModal'
+import NotificationsPanel from '@/components/support/NotificationsPanel'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
       <ToastProvider>
-        {children}
+        <SupportProvider>
+          {children}
+          <SupportModal />
+          <NotificationsPanel />
+        </SupportProvider>
         <ToastContainer />
       </ToastProvider>
     </AuthProvider>

--- a/lib/support-context.tsx
+++ b/lib/support-context.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { useAuth } from '@/lib/auth-context'
+
+export type SupportTab = 'bug' | 'feature' | 'help'
+
+interface SupportContextValue {
+  helpOpen: boolean
+  activeTab: SupportTab
+  openHelp: (tab?: SupportTab) => void
+  closeHelp: () => void
+  notificationsOpen: boolean
+  openNotifications: () => void
+  closeNotifications: () => void
+  unreadCount: number
+}
+
+const SupportContext = createContext<SupportContextValue | null>(null)
+
+export function SupportProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState<SupportTab>('bug')
+  const [notificationsOpen, setNotificationsOpen] = useState(false)
+  const unreadCount = 0
+
+  const openHelp = useCallback((tab: SupportTab = 'bug') => {
+    setNotificationsOpen(false)
+    setActiveTab(tab)
+    setHelpOpen(true)
+  }, [])
+
+  const closeHelp = useCallback(() => setHelpOpen(false), [])
+
+  const openNotifications = useCallback(() => {
+    setHelpOpen(false)
+    setNotificationsOpen(true)
+  }, [])
+
+  const closeNotifications = useCallback(() => setNotificationsOpen(false), [])
+
+  useEffect(() => {
+    if (!user) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.shiftKey && e.key === '?' && !helpOpen) {
+        e.preventDefault()
+        openHelp()
+      }
+      if (e.key === 'Escape') {
+        setHelpOpen(false)
+        setNotificationsOpen(false)
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [user, helpOpen, openHelp])
+
+  return (
+    <SupportContext.Provider value={{
+      helpOpen, activeTab, openHelp, closeHelp,
+      notificationsOpen, openNotifications, closeNotifications,
+      unreadCount,
+    }}>
+      {children}
+    </SupportContext.Provider>
+  )
+}
+
+export function useSupportContext() {
+  const ctx = useContext(SupportContext)
+  if (!ctx) throw new Error('useSupportContext must be used inside SupportProvider')
+  return ctx
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
+        "playwright": "^1.59.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.2"
       }
@@ -7722,6 +7723,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
+    "playwright": "^1.59.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.2"
   }

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -1,4 +1,4 @@
-export type FeedbackType = 'feature_request' | 'bug_report'
+export type FeedbackType = 'feature_request' | 'bug_report' | 'support'
 export type FeedbackStatus = 'open' | 'in_progress' | 'done' | 'wont_fix'
 export type FeedbackPriority = 'low' | 'medium' | 'high'
 
@@ -11,6 +11,7 @@ export interface OperatorFeedback {
   submittedBy: string        // uid
   companyId: string
   companyName: string
+  userName: string
   status: FeedbackStatus
   priority: FeedbackPriority
 }


### PR DESCRIPTION
## Summary

- Adds a **notifications bell** in the primary nav (desktop) that opens a fixed panel — empty state for now, ready to be wired to real data
- Adds a **3-tab support modal** (Bug report / Feature request / Get help) triggered by the help icon or `Shift+?`
- Submissions are written to the existing `operatorFeedback` Firestore collection via a new `submitFeedback` server action; tickets appear immediately in the operator dashboard
- **Mobile**: both panels are accessible from the hamburger drawer under a new "More" section

## Details

- `lib/support-context.tsx` — global state for modal/panel open state, active tab, unread count, and keyboard shortcuts
- `actions/submitFeedback.ts` — server action using `getVerifiedSession()`; generates `BUG-XXXX` / `FEA-XXXX` / `SUP-XXXX` ticket IDs
- `lib/action-tracker.ts` — thin client-side ring buffer (50 entries) used by the optional diagnostics payload
- `types/operator.ts` — added `'support'` to `FeedbackType`; added `userName` field to `OperatorFeedback`
- GDPR: diagnostics checkbox is **unchecked by default** (opt-in, not opt-out)
- Severity is required but **not pre-selected** on the bug form

## Test plan

- [ ] Click bell icon (desktop) → notifications panel opens, shows empty state, closes on outside-click and Escape
- [ ] Click help icon (desktop) → modal opens on Bug report tab
- [ ] `Shift+?` → opens modal from anywhere in the app
- [ ] Fill in bug report (headline + steps + severity) → Send button enables → submit → success state with ticket ID → toast appears → modal auto-closes
- [ ] Switch to Feature request and Get help tabs — validate form works end-to-end
- [ ] Check `/operator/feedback` → submitted ticket appears with correct type, userName, companyName
- [ ] Resize to mobile → bell + help icons hidden in nav → open hamburger → "More" section shows Notifications + Help & feedback → clicking each opens the correct panel/modal
- [ ] `npx tsc --noEmit` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)