### PR TITLE
Add environment badge and page title for non-production environments

### DIFF
--- a/app/(auth)/auth-layout.module.css
+++ b/app/(auth)/auth-layout.module.css
@@ -26,6 +26,32 @@
   justify-content: center;
 }
 
+.envBadge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 4px;
+  margin-left: 10px;
+  line-height: 1;
+}
+
+.envBadge_dev {
+  background: var(--surface-container-highest);
+  color: var(--outline);
+}
+
+.envBadge_alpha {
+  background: #2a2200;
+  color: var(--accent);
+}
+
+.envBadge_beta {
+  background: #1a1a2e;
+  color: #7b9cff;
+}
+
 .authFooter {
   display: flex;
   justify-content: space-between;

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,12 +1,26 @@
 import Link from 'next/link'
 import styles from './auth-layout.module.css'
 
+const ENV_LABELS: Record<string, string> = {
+  dev:   'Dev',
+  alpha: 'Alpha',
+  beta:  'Beta',
+}
+
 // Minimal shell for unauthenticated routes — auth header/footer, no nav, no auth check.
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  const env = process.env.NEXT_PUBLIC_APP_ENV
+  const envLabel = env ? ENV_LABELS[env] : undefined
+
   return (
     <div className={styles.authShell}>
       <header className={styles.authHeader}>
         <span className={styles.wordmark}>ALLOCATE</span>
+        {envLabel && (
+          <span className={`${styles.envBadge} ${styles[`envBadge_${env}`]}`}>
+            {envLabel}
+          </span>
+        )}
       </header>
       <main className={styles.authMain}>{children}</main>
       <footer className={styles.authFooter}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,8 +18,11 @@ const generalSans = localFont({
   display: 'swap',
 })
 
+const ENV_LABELS: Record<string, string> = { dev: 'Dev', alpha: 'Alpha', beta: 'Beta' }
+const envLabel = ENV_LABELS[process.env.NEXT_PUBLIC_APP_ENV ?? '']
+
 export const metadata: Metadata = {
-  title:       'Allocate',
+  title:       envLabel ? `Allocate (${envLabel})` : 'Allocate',
   description: 'Film production equipment booking',
 }
 

--- a/components/nav/LogoRow.module.css
+++ b/components/nav/LogoRow.module.css
@@ -9,6 +9,38 @@
   flex-direction: column;
 }
 
+.logoLine {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.envBadge {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+  line-height: 1;
+}
+
+.envBadge_dev {
+  background: var(--surface-container-highest);
+  color: var(--outline);
+}
+
+.envBadge_alpha {
+  background: #2a2200;
+  color: var(--accent);
+}
+
+.envBadge_beta {
+  background: #1a1a2e;
+  color: #7b9cff;
+}
+
 .logo {
   font-size: var(--font-logo);
   font-weight: 900;

--- a/components/nav/LogoRow.tsx
+++ b/components/nav/LogoRow.tsx
@@ -7,16 +7,27 @@ interface LogoRowProps {
   rightContent?: React.ReactNode
 }
 
-/**
- * LogoRow — Server Component.
- * Renders the large "Allocate" wordmark and an optional contextual
- * right-side element (week nav, item counts, etc.).
- */
+const ENV_LABELS: Record<string, string> = {
+  dev:   'Dev',
+  alpha: 'Alpha',
+  beta:  'Beta',
+}
+
 export default function LogoRow({ rightContent }: LogoRowProps) {
+  const env = process.env.NEXT_PUBLIC_APP_ENV
+  const envLabel = env ? ENV_LABELS[env] : undefined
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.logoBlock}>
-        <span className={styles.logo}>Allocate</span>
+        <div className={styles.logoLine}>
+          <span className={styles.logo}>Allocate</span>
+          {envLabel && (
+            <span className={`${styles.envBadge} ${styles[`envBadge_${env}`]}`}>
+              {envLabel}
+            </span>
+          )}
+        </div>
         <div className={styles.subRow}>
           <span className={styles.subLabel}>Gear Management System</span>
           {rightContent && (

--- a/components/nav/PrimaryNav.module.css
+++ b/components/nav/PrimaryNav.module.css
@@ -17,12 +17,43 @@
   padding: 16px 24px;
 }
 
+.wordmarkGroup {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .wordmark {
   font-size: 1.25rem;
   font-weight: 900;
   letter-spacing: -0.04em;
   text-transform: uppercase;
   color: var(--white);
+}
+
+.envBadge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.envBadge_dev {
+  background: var(--surface-container-highest);
+  color: var(--outline);
+}
+
+.envBadge_alpha {
+  background: #2a2200;
+  color: var(--accent);
+}
+
+.envBadge_beta {
+  background: #1a1a2e;
+  color: #7b9cff;
 }
 
 .links {

--- a/components/nav/PrimaryNav.tsx
+++ b/components/nav/PrimaryNav.tsx
@@ -5,6 +5,12 @@ import type { Role } from '@/types'
 import { useSupportContext } from '@/lib/support-context'
 import styles from './PrimaryNav.module.css'
 
+const ENV_LABELS: Record<string, string> = {
+  dev:   'Dev',
+  alpha: 'Alpha',
+  beta:  'Beta',
+}
+
 interface PrimaryNavProps {
   role: Role
 }
@@ -22,7 +28,14 @@ export default function PrimaryNav({ role }: PrimaryNavProps) {
   return (
     <nav className={styles.nav}>
       <div className={styles.inner}>
-        <span className={styles.wordmark}>ALLOCATE</span>
+        <div className={styles.wordmarkGroup}>
+          <span className={styles.wordmark}>ALLOCATE</span>
+          {process.env.NEXT_PUBLIC_APP_ENV && ENV_LABELS[process.env.NEXT_PUBLIC_APP_ENV] && (
+            <span className={`${styles.envBadge} ${styles[`envBadge_${process.env.NEXT_PUBLIC_APP_ENV}`]}`}>
+              {ENV_LABELS[process.env.NEXT_PUBLIC_APP_ENV]}
+            </span>
+          )}
+        </div>
 
         <div className={styles.links}>
           <Link


### PR DESCRIPTION
## Summary
- Adds a **DEV / ALPHA / BETA** badge next to the ALLOCATE wordmark in the nav (logged-in view), auth layout (sign-in/up), and LogoRow
- Appends **(Dev) / (Alpha) / (Beta)** to the browser tab `<title>`
- Prod shows nothing — badge and title suffix only appear when `NEXT_PUBLIC_APP_ENV` is set
- Local dev now points to `allocate-alpha` for Firestore and Auth

## How it works
Set `NEXT_PUBLIC_APP_ENV` per environment:
- `.env.local` → `dev`
- Alpha backend (Firebase Console) → `alpha`
- Beta backend (Firebase Console) → `beta`
- Prod → variable not set (no badge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)