### PR TITLE
Fix apphosting.yaml: restore prod value fields

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,9 +1,9 @@
 # Firebase App Hosting configuration
 # Docs: https://firebase.google.com/docs/app-hosting/configure
 #
-# NEXT_PUBLIC_FIREBASE_* and NEXT_PUBLIC_APP_URL are NOT hardcoded here —
-# they differ per environment (alpha/beta/prod) and are set per-backend via:
-#   firebase --project <id> apphosting:config:set KEY="value"
+# NEXT_PUBLIC_FIREBASE_* values below are the prod (allocate-e0735) defaults.
+# Alpha and beta backends override these via Firebase Console → App Hosting →
+# Backend → Environment variables (per-backend overrides take precedence).
 
 runConfig:
   minInstances: 0
@@ -13,36 +13,45 @@ runConfig:
   memoryMiB: 512
 
 env:
-  # Public Firebase client config — set per-backend, needed at build time.
+  # Public Firebase client config — prod values as default.
+  # Override per-backend in Firebase Console for alpha and beta.
   - variable: NEXT_PUBLIC_FIREBASE_API_KEY
+    value: "AIzaSyDlmC62B2RS-zO_YseqbcOs4gpzKaiVd-A"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    value: "allocate-e0735.firebaseapp.com"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    value: "allocate-e0735"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    value: "allocate-e0735.firebasestorage.app"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    value: "5366151572"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_APP_ID
+    value: "1:5366151572:web:f63b276838880215053781"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+    value: "G-02WW3DDDPD"
     availability:
       - BUILD
       - RUNTIME
   - variable: NEXT_PUBLIC_APP_URL
+    value: "https://allocate--allocate-e0735.europe-west4.hosted.app"
     availability:
       - BUILD
       - RUNTIME


### PR DESCRIPTION
## Summary
- Restores `value` fields for all `NEXT_PUBLIC_FIREBASE_*` and `NEXT_PUBLIC_APP_URL` variables in `apphosting.yaml`
- Firebase App Hosting requires every env var entry to have either `value` or `secret` — entries with only `availability` cause build failures on all backends
- Prod values are the defaults; alpha and beta override via Firebase Console per-backend environment variables

## Root cause
A previous change removed the hardcoded `value` fields intending to make them per-backend configurable, but left entries with only `availability` which is an invalid configuration.

## Test plan
- [ ] All three App Hosting backends (prod, alpha, beta) successfully build after merge
- [ ] Alpha and beta still use their own Firebase config (set via Firebase Console overrides)