### PR TITLE
fix: remove prod credentials from apphosting.yaml

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,9 +1,7 @@
-# Firebase App Hosting configuration
+# Firebase App Hosting — base configuration
+# Firebase credentials and env-specific values are managed per-backend
+# in Firebase Console → App Hosting → Environment variables.
 # Docs: https://firebase.google.com/docs/app-hosting/configure
-#
-# NEXT_PUBLIC_FIREBASE_* values below are the prod (allocate-e0735) defaults.
-# Alpha and beta backends override these via Firebase Console → App Hosting →
-# Backend → Environment variables (per-backend overrides take precedence).
 
 runConfig:
   minInstances: 0
@@ -13,61 +11,7 @@ runConfig:
   memoryMiB: 512
 
 env:
-  # Public Firebase client config — prod values as default.
-  # Override per-backend in Firebase Console for alpha and beta.
-  - variable: NEXT_PUBLIC_FIREBASE_API_KEY
-    value: "AIzaSyDlmC62B2RS-zO_YseqbcOs4gpzKaiVd-A"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
-    value: "allocate-e0735.firebaseapp.com"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID
-    value: "allocate-e0735"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
-    value: "allocate-e0735.firebasestorage.app"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
-    value: "5366151572"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_APP_ID
-    value: "1:5366151572:web:f63b276838880215053781"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
-    value: "G-02WW3DDDPD"
-    availability:
-      - BUILD
-      - RUNTIME
-  - variable: NEXT_PUBLIC_APP_URL
-    value: "https://allocate--allocate-e0735.europe-west4.hosted.app"
-    availability:
-      - BUILD
-      - RUNTIME
-
-  # Stripe price IDs — non-secret, runtime only.
-  - variable: STRIPE_PRICE_STARTER_MONTHLY
-    value: "price_1Q0r0X06TtFrNVu39VXac7MQ"
-    availability:
-      - RUNTIME
-  - variable: STRIPE_PRICE_STARTER_YEARLY
-    value: "price_1Q0N5206TtFrNVu3B1rlpJYi"
-    availability:
-      - RUNTIME
-
-  # Secrets — managed in Google Secret Manager.
-  # Create with: firebase apphosting:secrets:set <NAME>
+  # Secrets — resolved from each backend's own Google Secret Manager project
   - variable: FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON
     secret: FIREBASE_ADMIN_SERVICE_ACCOUNT_JSON
     availability:


### PR DESCRIPTION
## Summary

Tar bort hårdkodade prod-credentials från \`apphosting.yaml\`.

Firebase-config och andra env-specifika värden hanteras per-backend via Firebase Console → App Hosting → Environment variables (vilket redan är korrekt satt för alla tre backends).

**Före:** \`apphosting.yaml\` innehöll prod-credentials som fallback. Om Console-overrides rensades pekade alpha/beta tyst mot prod.

**Efter:** \`apphosting.yaml\` innehåller bara \`runConfig\` och secret-references. Om Console-overrides saknas kraschar appen med undefined-variabler (synligt fel) istället för att tyst använda fel projekt.

## Test plan

- [ ] Verifiera att alpha- och beta-backends redeployar utan fel
- [ ] Kontrollera att miljöbadgen och Firebase-config är korrekt per backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)