### PR TITLE
fix(list): eliminera dubbla bokningsrader i listvyn

### DIFF
--- a/components/bookings/BookingList.module.css
+++ b/components/bookings/BookingList.module.css
@@ -90,7 +90,7 @@
   gap: 16px;
   padding-top: 48px;
   padding-bottom: 32px;
-  background: var(--surface, #0f0f0f);
+  background: var(--black);
 }
 
 .groupHeaderFirst {

--- a/components/bookings/BookingList.module.css
+++ b/components/bookings/BookingList.module.css
@@ -40,6 +40,7 @@
 .controls {
   display: flex;
   align-items: center;
+  gap: 8px;
   margin-bottom: 24px;
 }
 
@@ -61,6 +62,23 @@
   border-color: var(--white);
 }
 
+.todayBtn {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #919191;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.todayBtn:hover {
+  color: #fff;
+}
+
 /* Date group */
 .group {
   margin-bottom: 64px;
@@ -70,7 +88,18 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-bottom: 32px;
+  padding-top: 48px;
+  padding-bottom: 32px;
+  background: var(--surface, #0f0f0f);
+}
+
+.groupHeaderFirst {
+  padding-top: 0;
+}
+
+/* Wrapper around each booking card in the virtualized list */
+.bookingCardWrapper {
+  padding-bottom: 16px;
 }
 
 .dateLabel {

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -151,6 +151,13 @@ export default function BookingList({
 
   const virtuosoRef = useRef<GroupedVirtuosoHandle>(null)
 
+  // Delay mounting the virtuoso until client-side hydration is complete.
+  // GroupedVirtuoso renders a different subset on SSR vs client (SSR renders
+  // item 0; client renders from initialTopMostItemIndex), which causes React
+  // to detect a hydration mismatch and render both — resulting in duplicates.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => { setMounted(true) }, [])
+
   // After live data loads, re-scroll to today so the position reflects the
   // full dataset (initial server data may have a different offset).
   useEffect(() => {
@@ -210,8 +217,12 @@ export default function BookingList({
         </div>
       )}
 
-      {/* Virtualized date-grouped list */}
-      {sortedDates.length > 0 && (
+      {/* Virtualized date-grouped list — only rendered client-side to avoid
+          SSR/hydration mismatch that caused duplicate booking rows. */}
+      {sortedDates.length > 0 && !mounted && (
+        <div style={{ height: 'calc(100svh - 300px)', minHeight: '300px' }} />
+      )}
+      {sortedDates.length > 0 && mounted && (
         <GroupedVirtuoso
           ref={virtuosoRef}
           style={{ height: 'calc(100svh - 300px)', minHeight: '300px' }}

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -214,7 +214,7 @@ export default function BookingList({
       {sortedDates.length > 0 && (
         <GroupedVirtuoso
           ref={virtuosoRef}
-          useWindowScroll
+          style={{ height: 'calc(100svh - 300px)', minHeight: '300px' }}
           groupCounts={groupCounts}
           initialTopMostItemIndex={todayItemIndex}
           groupContent={(index) => {

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import Link from 'next/link'
+import { GroupedVirtuoso, type GroupedVirtuosoHandle } from 'react-virtuoso'
 import { useBookings } from '@/hooks/useBookings'
 import type { Booking, Role, UserProfile } from '@/types'
 import styles from './BookingList.module.css'
@@ -40,22 +41,12 @@ function groupBookingsByDate(bookings: Booking[]): Map<string, Booking[]> {
 function formatDateLabel(dateStr: string, today: string, tomorrow: string): string {
   if (dateStr === today) return 'Today'
   if (dateStr === tomorrow) return 'Tomorrow'
-  // Format as "Mon 23 Mar" style
   const d = new Date(dateStr + 'T00:00:00')
   return d.toLocaleDateString('en-GB', {
     weekday: 'short',
     day: 'numeric',
     month: 'short',
   })
-}
-
-function formatFullDate(dateStr: string): string {
-  const d = new Date(dateStr + 'T00:00:00')
-  return d.toLocaleDateString('en-GB', {
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-  }).toUpperCase()
 }
 
 // ---------------------------------------------------------------------------
@@ -90,8 +81,17 @@ export default function BookingList({
   const [showCancelled, setShowCancelled] = useState(false)
   const [showOnlyMine, setShowOnlyMine] = useState(false)
 
+  // Load a large window so past and future bookings up to 5 years in each
+  // direction are available without extra fetches.
+  const fiveYearsAgo = useMemo(() => {
+    const d = new Date()
+    d.setFullYear(d.getFullYear() - 5)
+    return d.toISOString().slice(0, 10)
+  }, [])
+
   const { bookings: liveBookings, loading, error } = useBookings(companyId, {
     includeCancelled: showCancelled,
+    startDate: fiveYearsAgo,
   })
 
   // Use live data once the listener has fired; fall back to server-fetched initial data.
@@ -112,7 +112,7 @@ export default function BookingList({
   const stats = useMemo(() => computeStats(visibleBookings, today), [visibleBookings, today])
   void stats // prevent unused variable warning
 
-  // Group non-cancelled bookings by startDate, sorted newest first.
+  // Group by startDate, filtered, sorted oldest → newest.
   const grouped = useMemo(() => {
     const all = showCancelled
       ? visibleBookings
@@ -121,9 +121,44 @@ export default function BookingList({
   }, [visibleBookings, showCancelled])
 
   const sortedDates = useMemo(
-    () => Array.from(grouped.keys()).sort((a, b) => (a > b ? -1 : 1)),
+    () => Array.from(grouped.keys()).sort((a, b) => (a > b ? 1 : -1)),
     [grouped],
   )
+
+  // Flat booking array in date order for O(1) lookup by virtuoso index.
+  const flatBookings = useMemo(
+    () => sortedDates.flatMap((d) => grouped.get(d) ?? []),
+    [sortedDates, grouped],
+  )
+
+  // Number of booking items per date group.
+  const groupCounts = useMemo(
+    () => sortedDates.map((d) => (grouped.get(d) ?? []).length),
+    [sortedDates, grouped],
+  )
+
+  // Flat item index of the first booking on or after today.
+  // Used for initial scroll position and the Today button.
+  const todayItemIndex = useMemo(() => {
+    let offset = 0
+    for (let i = 0; i < sortedDates.length; i++) {
+      if (sortedDates[i] >= today) return offset
+      offset += groupCounts[i]
+    }
+    // All dates are in the past — scroll to the last item.
+    return Math.max(0, flatBookings.length - 1)
+  }, [sortedDates, groupCounts, flatBookings.length, today])
+
+  const virtuosoRef = useRef<GroupedVirtuosoHandle>(null)
+
+  // After live data loads, re-scroll to today so the position reflects the
+  // full dataset (initial server data may have a different offset).
+  useEffect(() => {
+    if (!loading && flatBookings.length > 0) {
+      virtuosoRef.current?.scrollToIndex({ index: todayItemIndex, align: 'start' })
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading]) // intentionally only fires when loading flips to false
 
   if (error) {
     return (
@@ -136,20 +171,7 @@ export default function BookingList({
   return (
     <div className={styles.container}>
       {/* Stats bar — logic preserved, UI hidden per redesign spec */}
-      {/* <div className={styles.statsBar}>
-        <div className={styles.stat}>
-          <span className={styles.statValue}>{stats.bookingsToday}</span>
-          <span className={styles.statLabel}>Bookings today</span>
-        </div>
-        <div className={styles.stat}>
-          <span className={styles.statValue}>{stats.itemsOut}</span>
-          <span className={styles.statLabel}>Items out</span>
-        </div>
-        <div className={styles.stat}>
-          <span className={styles.statValue}>{stats.pendingApprovals}</span>
-          <span className={styles.statLabel}>Pending approvals</span>
-        </div>
-      </div> */}
+      {/* <div className={styles.statsBar}>…</div> */}
 
       {/* Controls */}
       <div className={styles.controls}>
@@ -164,6 +186,14 @@ export default function BookingList({
           onClick={() => setShowOnlyMine((v) => !v)}
         >
           {showOnlyMine ? 'Show all' : 'Only mine'}
+        </button>
+        <button
+          className={styles.todayBtn}
+          onClick={() =>
+            virtuosoRef.current?.scrollToIndex({ index: todayItemIndex, align: 'start', behavior: 'smooth' })
+          }
+        >
+          Today
         </button>
       </div>
 
@@ -180,45 +210,37 @@ export default function BookingList({
         </div>
       )}
 
-      {/* Date groups */}
-      {sortedDates.map((dateStr) => {
-        const dateBookings = grouped.get(dateStr) ?? []
-        const label = formatDateLabel(dateStr, today, tomorrow)
-        const isToday = dateStr === today
-
-        return (
-          <div key={dateStr} id={`group-${dateStr}`} className={styles.group}>
-            <div className={styles.groupHeader}>
-              <label className={styles.dateLabelWrap}>
+      {/* Virtualized date-grouped list */}
+      {sortedDates.length > 0 && (
+        <GroupedVirtuoso
+          ref={virtuosoRef}
+          useWindowScroll
+          groupCounts={groupCounts}
+          initialTopMostItemIndex={todayItemIndex}
+          groupContent={(index) => {
+            const dateStr  = sortedDates[index]
+            const label    = formatDateLabel(dateStr, today, tomorrow)
+            const isToday  = dateStr === today
+            return (
+              <div className={`${styles.groupHeader} ${index === 0 ? styles.groupHeaderFirst : ''}`}>
                 <span className={`${styles.dateLabel} ${isToday ? styles.dateLabelToday : ''}`}>
                   {label.toUpperCase()}
                 </span>
-                <input
-                  type="date"
-                  defaultValue={dateStr}
-                  onChange={(e) => {
-                    if (!e.target.value) return
-                    const target = e.target.value
-                    const nearest = [...sortedDates].reverse().find((d) => d >= target) ?? sortedDates[0]
-                    if (nearest) document.getElementById(`group-${nearest}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-                  }}
-                  className={styles.overlayDateInput}
-                />
-              </label>
-              <div className={styles.groupRule} />
-            </div>
-            <div className={styles.bookingCards}>
-              {dateBookings.map((booking) => (
-                <BookingRow
-                  key={booking.id}
-                  booking={booking}
-                  userProfiles={userProfiles}
-                />
-              ))}
-            </div>
-          </div>
-        )
-      })}
+                <div className={styles.groupRule} />
+              </div>
+            )
+          }}
+          itemContent={(index) => {
+            const booking = flatBookings[index]
+            if (!booking) return <div />
+            return (
+              <div className={styles.bookingCardWrapper}>
+                <BookingRow booking={booking} userProfiles={userProfiles} />
+              </div>
+            )
+          }}
+        />
+      )}
     </div>
   )
 }
@@ -227,7 +249,6 @@ export default function BookingList({
 // Booking row
 // ---------------------------------------------------------------------------
 
-// Status display helpers
 const STATUS_LABELS: Record<string, string> = {
   checked_out: 'CHECKED OUT',
   confirmed:   'CONFIRMED',
@@ -319,14 +340,6 @@ function BookingRow({
   )
 }
 
-function formatShortDate(dateStr: string): string {
-  const d = new Date(dateStr + 'T00:00:00')
-  return d.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-  })
-}
-
 function formatBookingDateTime(
   startDate: string,
   endDate: string,
@@ -352,24 +365,17 @@ function formatBookingDateTime(
   const hasTime = startTime && endTime
 
   if (hasTime) {
-    // With time: show start date/time - end date/time
     if (sameDay) {
-      // Same day: "23 apr 12:03-13:45"
       return `${formatMonthDay(startDate)} ${startTime}-${endTime}`
     } else {
-      // Multiple days: "23 apr 12:03 - 25 maj 14:32"
       return `${formatMonthDay(startDate)} ${startTime} - ${formatMonthDay(endDate)} ${endTime}`
     }
   } else {
-    // All day: show date only
     if (sameDay) {
-      // Same day: "23 apr"
       return formatMonthDay(startDate)
     } else if (sameMonth) {
-      // Same month: "23 - 25 apr"
       return `${start.day} - ${formatMonthDay(endDate)}`
     } else {
-      // Different months: "23 apr - 25 maj"
       return `${formatMonthDay(startDate)} - ${formatMonthDay(endDate)}`
     }
   }

--- a/components/bookings/BookingList.tsx
+++ b/components/bookings/BookingList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import Link from 'next/link'
 import { GroupedVirtuoso, type GroupedVirtuosoHandle } from 'react-virtuoso'
 import { useBookings } from '@/hooks/useBookings'
@@ -151,22 +151,6 @@ export default function BookingList({
 
   const virtuosoRef = useRef<GroupedVirtuosoHandle>(null)
 
-  // Delay mounting the virtuoso until client-side hydration is complete.
-  // GroupedVirtuoso renders a different subset on SSR vs client (SSR renders
-  // item 0; client renders from initialTopMostItemIndex), which causes React
-  // to detect a hydration mismatch and render both — resulting in duplicates.
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => { setMounted(true) }, [])
-
-  // After live data loads, re-scroll to today so the position reflects the
-  // full dataset (initial server data may have a different offset).
-  useEffect(() => {
-    if (!loading && flatBookings.length > 0) {
-      virtuosoRef.current?.scrollToIndex({ index: todayItemIndex, align: 'start' })
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading]) // intentionally only fires when loading flips to false
-
   if (error) {
     return (
       <div className={styles.errorState}>
@@ -217,12 +201,13 @@ export default function BookingList({
         </div>
       )}
 
-      {/* Virtualized date-grouped list — only rendered client-side to avoid
-          SSR/hydration mismatch that caused duplicate booking rows. */}
-      {sortedDates.length > 0 && !mounted && (
+      {/* Virtualized date-grouped list. Mounted once Firestore data has loaded so
+          Virtuoso receives a stable dataset and the right initialTopMostItemIndex
+          on first render — prevents the previous data-swap-mid-mount duplicate. */}
+      {sortedDates.length > 0 && loading && (
         <div style={{ height: 'calc(100svh - 300px)', minHeight: '300px' }} />
       )}
-      {sortedDates.length > 0 && mounted && (
+      {sortedDates.length > 0 && !loading && (
         <GroupedVirtuoso
           ref={virtuosoRef}
           style={{ height: 'calc(100svh - 300px)', minHeight: '300px' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "16.2.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-virtuoso": "^4.18.7",
         "server-only": "^0.0.1",
         "stripe": "^20.4.1"
       },
@@ -7927,6 +7928,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.7",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.7.tgz",
+      "integrity": "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-virtuoso": "^4.18.7",
     "server-only": "^0.0.1",
     "stripe": "^20.4.1"
   },


### PR DESCRIPTION
## Sammanfattning
- Ersätter `mounted`-state-hacken med `loading`-guard i `BookingList.tsx`
- `GroupedVirtuoso` monteras nu en gång med stabil `liveBookings`-datakälla
- Eliminerar dubbla rader orsakade av data-swap mid-mount

## Rotorsak
`useBookings` startar med `loading=true` och byter sedan till `liveBookings` när Firestore `onSnapshot` levererar. Tidigare monterades Virtuoso direkt med `initialBookings`, sedan byttes `groupCounts`/`flatBookings` vid dataleverans — Virtuoso lämnade kvar sin layout från första passet, vilket såg ut som "alla bokningar visas dubbelt".

## Verifiering
- Lokalt: `/bookings/list` visar varje bokning exakt en gång
- "Today"-knapp scrollar korrekt
- Toggle "Show cancelled" / "Only mine" uppdaterar utan duplikat

🤖 Generated with [Claude Code](https://claude.com/claude-code)