### PR TITLE
fix(middleware): exclude /fonts/ from auth guard

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -41,5 +41,5 @@ export function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\.png$).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\.png$|fonts/).*)'],
 }


### PR DESCRIPTION
## Summary

- Font files i `/fonts/` matchades av middleware auth guard
- Middleware redirectade unauthenticerade font-requests (307 → `/login`)
- Material Symbols-ikoner (`notifications`, `help`, m.fl.) renderades som vanlig text efter att `font-display: block`-perioden löpte ut
- Fix: lade till `fonts/` i matcher-undantaget

**Rotorsak:** `proxy.ts` matcher `/((?!api|_next/static|_next/image|favicon.ico|.*\\.png$).*)` exkluderade inte `/fonts/`, så `material-symbols-outlined.woff2` skyddades av auth-checken. Fonter är publika static assets och kräver inte session-cookie.

## Test plan

- [ ] Verifiera att `curl http://localhost:3000/fonts/material-symbols-outlined.woff2` returnerar 200 utan cookie
- [ ] Logga in och bekräfta att notification- och help-ikoner visas i navbaren (inte text)
- [ ] Verifiera att ikoner fungerar på deployed alpha efter promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)