### PR TITLE
Fix: Stripe price not configured in alpha/beta

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -24,3 +24,11 @@ env:
     secret: STRIPE_WEBHOOK_SECRET
     availability:
       - RUNTIME
+  - variable: STRIPE_PRICE_STARTER_MONTHLY
+    secret: STRIPE_PRICE_STARTER_MONTHLY
+    availability:
+      - RUNTIME
+  - variable: STRIPE_PRICE_STARTER_YEARLY
+    secret: STRIPE_PRICE_STARTER_YEARLY
+    availability:
+      - RUNTIME


### PR DESCRIPTION
## Summary
- Adds `STRIPE_PRICE_STARTER_MONTHLY` and `STRIPE_PRICE_STARTER_YEARLY` to `apphosting.yaml` so Firebase App Hosting resolves them from Secret Manager at runtime
- These vars were only in `.env.local` (local dev) — missing in deployed alpha/beta environments caused "Stripe price not configured" on plan selection

## Before merging
Secrets must exist in Secret Manager for each project:
```bash
# Alpha
echo -n "price_1Q0r0X06TtFrNVu39VXac7MQ" | gcloud secrets create STRIPE_PRICE_STARTER_MONTHLY --data-file=- --project=allocate-alpha
echo -n "price_1Q0N5206TtFrNVu3B1rlpJYi" | gcloud secrets create STRIPE_PRICE_STARTER_YEARLY --data-file=- --project=allocate-alpha

# Beta
echo -n "price_1Q0r0X06TtFrNVu39VXac7MQ" | gcloud secrets create STRIPE_PRICE_STARTER_MONTHLY --data-file=- --project=allocate-beta
echo -n "price_1Q0N5206TtFrNVu3B1rlpJYi" | gcloud secrets create STRIPE_PRICE_STARTER_YEARLY --data-file=- --project=allocate-beta
```

## Test plan
- [ ] Secrets skapade i Secret Manager för alpha och beta
- [ ] PR mergad, alpha/beta redeploy triggas
- [ ] Skapa konto i alpha → välj plan → Stripe Checkout öppnas utan fel
- [ ] Samma test i beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)