### PR TITLE
Fix: Stripe price not configured in alpha

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -24,3 +24,11 @@ env:
     secret: STRIPE_WEBHOOK_SECRET
     availability:
       - RUNTIME
+  - variable: STRIPE_PRICE_STARTER_MONTHLY
+    secret: STRIPE_PRICE_STARTER_MONTHLY
+    availability:
+      - RUNTIME
+  - variable: STRIPE_PRICE_STARTER_YEARLY
+    secret: STRIPE_PRICE_STARTER_YEARLY
+    availability:
+      - RUNTIME


### PR DESCRIPTION
## Summary
Promotes fix from dev: adds `STRIPE_PRICE_STARTER_MONTHLY` and `STRIPE_PRICE_STARTER_YEARLY` to `apphosting.yaml` so Firebase App Hosting resolves them from Secret Manager.

Secrets already created in Secret Manager for `allocate-alpha`.

## Test plan
- [ ] Alpha redeploys efter merge
- [ ] Skapa konto i alpha → välj plan → Stripe Checkout öppnas utan fel

🤖 Generated with [Claude Code](https://claude.com/claude-code)