### PR TITLE
fix(layout): preload Material Symbols font for mobile icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,6 +33,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={generalSans.variable}>
+      <head>
+        <link
+          rel="preload"
+          href="/fonts/material-symbols-outlined.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+      </head>
       <body>
         <Providers>{children}</Providers>
       </body>


### PR DESCRIPTION
## Summary
- Icons in the mobile menu rendered as plain text ("menu", "close") on mobile devices
- Root cause: the `material-symbols-outlined.woff2` font arrived too late — after the `font-display: block` timeout (~3s) — so the browser fell back to the system font, which has no ligature glyphs for icon names
- Fix: add `<link rel="preload">` in `app/layout.tsx` so the browser fetches the font file before CSS is even parsed, eliminating the race condition

## Test plan
- [ ] Open the alpha app on a real mobile device — hamburger icon should appear (not "menu")
- [ ] Open the mobile menu — close button should show an icon (not "close")
- [ ] In DevTools → Network, the `.woff2` font should appear near the top of the waterfall with `Initiator: link[rel=preload]`
- [ ] Desktop still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)