### PR TITLE
refactor(equipment): open add-modal via custom event instead of URL param

### DIFF
--- a/components/equipment/EquipmentList.tsx
+++ b/components/equipment/EquipmentList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { useEquipment } from '@/hooks/useEquipment'
 import EquipmentEmpty from './EquipmentEmpty'
@@ -54,9 +54,18 @@ export default function EquipmentList({ companyId, role, initialEquipment }: Equ
   const searchParams = useSearchParams()
   const openOnMount = role === 'admin' && searchParams.get('add') === '1'
 
-  // Unified modal state — pre-open if ?add=1 was present on first render
-  const [unifiedModalOpen, setUnifiedModalOpen] = useState(openOnMount)
+  const [unifiedModalOpen, setUnifiedModalOpen] = useState(false)
   const [unifiedModalEquipment, setUnifiedModalEquipment] = useState<Equipment | undefined>(undefined)
+
+  useEffect(() => {
+    if (openOnMount) setUnifiedModalOpen(true)
+  }, [openOnMount])
+
+  useEffect(() => {
+    const handler = () => { setUnifiedModalEquipment(undefined); setUnifiedModalOpen(true) }
+    window.addEventListener('equipment:open-add', handler)
+    return () => window.removeEventListener('equipment:open-add', handler)
+  }, [])
 
   function openAddModal() {
     setUnifiedModalEquipment(undefined)

--- a/components/nav/PrimaryNav.tsx
+++ b/components/nav/PrimaryNav.tsx
@@ -80,9 +80,12 @@ export default function PrimaryNav({ role }: PrimaryNavProps) {
           </div>
 
           {isActive('/equipment') && role === 'admin' ? (
-            <Link href="/equipment?add=1" className={styles.newBookingBtn}>
+            <button
+              className={styles.newBookingBtn}
+              onClick={() => window.dispatchEvent(new Event('equipment:open-add'))}
+            >
               NEW EQUIPMENT
-            </Link>
+            </button>
           ) : (
             <Link href="/bookings/new" className={styles.newBookingBtn}>
               NEW BOOKING


### PR DESCRIPTION
## Summary
- "NEW EQUIPMENT" button in `PrimaryNav` previously linked to `/equipment?add=1`, relying on a URL param to open the add modal
- This caused a race condition: `useState(openOnMount)` only runs once on mount, so client-side navigation to the same page didn't reliably re-trigger the modal
- Fix: button now dispatches a custom `equipment:open-add` event on `window`; `EquipmentList` listens for it and opens the modal via `useEffect`

## Test plan
- [ ] On the Equipment page, click "NEW EQUIPMENT" — add modal should open
- [ ] Navigate away and back, click again — modal should still open reliably
- [ ] URL should no longer change to `?add=1` when clicking the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)