### PR TITLE
Add Next.js rewrite for Firebase Auth action URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      // Firebase Auth email links require the path /__/auth/action.
+      // We rewrite internally to our custom handler at /auth/action.
+      {
+        source: '/__/auth/action',
+        destination: '/auth/action',
+      },
+    ]
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Firebase Console kräver att action URL:en använder sökvägen `/__/auth/action` — den accepterar inga andra sökvägar
- Lägger till en Next.js rewrite som mappar `/__/auth/action` → `/auth/action` internt
- I Firebase Console sätter du nu `https://alpha.allocate.at/__/auth/action` som custom action URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)