### PR TITLE
Promote dev → alpha: Firebase Auth action URL rewrite

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      // Firebase Auth email links require the path /__/auth/action.
+      // We rewrite internally to our custom handler at /auth/action.
+      {
+        source: '/__/auth/action',
+        destination: '/auth/action',
+      },
+    ]
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Promotar Next.js rewrite-fix från dev till alpha
- Möjliggör att sätta `https://alpha.allocate.at/__/auth/action` som custom action URL i Firebase Console

## Efter merge
Sätt custom action URL i Firebase Console (allocate-alpha):
`Authentication → Templates → Customize action URL → https://alpha.allocate.at/__/auth/action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)