### PR TITLE
promote: alpha → beta (Basic plan + in-app plan change)

### DIFF
--- a/actions/subscription.ts
+++ b/actions/subscription.ts
@@ -131,3 +131,51 @@ export async function createPortalSession(): Promise<{ url: string } | { error: 
     return { error: 'Could not open subscription portal' }
   }
 }
+
+// Opens the Billing Portal deep-linked straight to the subscription-update
+// (plan change) flow. The portal applies the change immediately with proration;
+// the customer.subscription.updated webhook then syncs plan/limits to Firestore.
+export async function createPlanChangeSession(): Promise<{ url: string } | { error: string }> {
+  const session = await getVerifiedSession()
+  if (session.role !== 'admin') return { error: 'Unauthorized' }
+  console.log('[actions/subscription]', { uid: session.uid.slice(0, 8) + '...', action: 'create_plan_change_session' })
+
+  try {
+    const companyId = session.activeCompanyId
+    const companySnap = await adminDb.doc(`companies/${companyId}`).get()
+    const companyData = companySnap.data() ?? {}
+
+    const stripeCustomerId: string = companyData.stripeCustomerId ?? ''
+    const stripeSubscriptionId: string = companyData.subscription?.stripeSubscriptionId ?? ''
+
+    if (!stripeCustomerId || !stripeSubscriptionId) {
+      return { error: 'No active subscription found' }
+    }
+
+    const params: Stripe.BillingPortal.SessionCreateParams = {
+      customer: stripeCustomerId,
+      return_url: `${process.env.NEXT_PUBLIC_APP_URL}/settings/subscription`,
+      flow_data: {
+        type: 'subscription_update',
+        subscription_update: { subscription: stripeSubscriptionId },
+      },
+    }
+
+    // Use the dedicated portal configuration (plan switching enabled) when set;
+    // otherwise fall back to the Stripe Dashboard default configuration.
+    if (process.env.STRIPE_PORTAL_CONFIG_ID) {
+      params.configuration = process.env.STRIPE_PORTAL_CONFIG_ID
+    }
+
+    const portalSession = await stripe.billingPortal.sessions.create(params)
+
+    return { url: portalSession.url }
+  } catch (err) {
+    console.error('[actions/subscription]', {
+      action: 'create_plan_change_session_error',
+      message: err instanceof Error ? err.message : String(err),
+      code: err instanceof Stripe.errors.StripeError ? err.code : undefined,
+    })
+    return { error: 'Could not open plan change portal' }
+  }
+}

--- a/actions/subscription.ts
+++ b/actions/subscription.ts
@@ -4,18 +4,28 @@ import { getVerifiedSession } from '@/lib/dal'
 import { stripe } from '@/lib/stripe'
 import { adminDb } from '@/lib/firebase-admin'
 import Stripe from 'stripe'
+import type { Plan } from '@/lib/subscription'
+
+const PRICE_ENV_BY_PLAN: Record<Plan, { month?: string; year?: string }> = {
+  starter: {
+    month: process.env.STRIPE_PRICE_STARTER_MONTHLY,
+    year:  process.env.STRIPE_PRICE_STARTER_YEARLY,
+  },
+  basic: {
+    month: process.env.STRIPE_PRICE_BASIC_MONTHLY,
+    year:  process.env.STRIPE_PRICE_BASIC_YEARLY,
+  },
+}
 
 export async function createCheckoutSession(
   interval: 'month' | 'year',
+  plan: Plan = 'starter',
 ): Promise<{ url: string } | { error: string }> {
   const session = await getVerifiedSession()
   if (session.role !== 'admin') return { error: 'Unauthorized' }
-  console.log('[actions/subscription]', { uid: session.uid.slice(0, 8) + '...', action: 'create_checkout_session' })
+  console.log('[actions/subscription]', { uid: session.uid.slice(0, 8) + '...', action: 'create_checkout_session', plan, interval })
 
-  const priceId =
-    interval === 'month'
-      ? process.env.STRIPE_PRICE_STARTER_MONTHLY
-      : process.env.STRIPE_PRICE_STARTER_YEARLY
+  const priceId = interval === 'month' ? PRICE_ENV_BY_PLAN[plan].month : PRICE_ENV_BY_PLAN[plan].year
 
   if (!priceId) return { error: 'Stripe price not configured' }
 
@@ -67,7 +77,7 @@ export async function createCheckoutSession(
     try {
       const checkoutSession = await stripe.checkout.sessions.create(
         sessionParams,
-        { idempotencyKey: `checkout-${companyId}-${interval}-${Math.floor(Date.now() / 60000)}` },
+        { idempotencyKey: `checkout-${companyId}-${plan}-${interval}-${Math.floor(Date.now() / 60000)}`},
       )
       return { url: checkoutSession.url! }
     } catch (err) {
@@ -83,7 +93,7 @@ export async function createCheckoutSession(
         await companyRef.update({ stripeCustomerId: newCustomer.id })
         const retrySession = await stripe.checkout.sessions.create(
           { ...sessionParams, customer: newCustomer.id },
-          { idempotencyKey: `checkout-${companyId}-${interval}-${Math.floor(Date.now() / 60000)}` },
+          { idempotencyKey: `checkout-${companyId}-${plan}-${interval}-${Math.floor(Date.now() / 60000)}`},
         )
         return { url: retrySession.url! }
       }

--- a/app/subscribe/SubscribePage.module.css
+++ b/app/subscribe/SubscribePage.module.css
@@ -29,6 +29,56 @@
   margin-bottom: 32px;
 }
 
+.planGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.planOption {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-align: left;
+  border: 1px solid rgba(71, 71, 71, 0.3);
+  padding: 20px 24px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s ease;
+}
+
+.planOptionActive {
+  border-color: rgba(238, 204, 2, 0.6);
+}
+
+.planOptionHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.planName {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--white);
+}
+
+.planPrice {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--white);
+}
+
+.planPriceUnit {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--mid);
+}
+
 .planBadge {
   display: inline-block;
   background: var(--accent);

--- a/app/subscribe/SubscribePage.tsx
+++ b/app/subscribe/SubscribePage.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react'
 import { createCheckoutSession } from '@/actions/subscription'
+import { PLAN_CATALOG, PLAN_ORDER, type PlanId } from '@/lib/plans'
 import s from './SubscribePage.module.css'
 
 export default function SubscribePage() {
+  const [plan, setPlan] = useState<PlanId>('starter')
   const [interval, setInterval] = useState<'month' | 'year'>('month')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -12,7 +14,7 @@ export default function SubscribePage() {
   async function handleSubscribe() {
     setLoading(true)
     setError(null)
-    const result = await createCheckoutSession(interval)
+    const result = await createCheckoutSession(interval, plan)
     if ('url' in result) {
       window.location.href = result.url
     } else {
@@ -26,13 +28,38 @@ export default function SubscribePage() {
       <h1 className={s.heading}>Subscribe</h1>
       <p className={s.subHeading}>Get started with Allocate</p>
 
-      <div className={s.planCard}>
-        <span className={s.planBadge}>Starter</span>
-        <div className={s.planFeatures}>
-          <span>25 equipment items</span>
-          <span className={s.featureSep}>·</span>
-          <span>10 members</span>
-        </div>
+      <div className={s.sectionLabel}>
+        <span>Plan</span>
+        <div className={s.rule} />
+      </div>
+
+      <div className={s.planGrid}>
+        {PLAN_ORDER.map((id) => {
+          const p = PLAN_CATALOG[id]
+          const price = interval === 'month' ? p.priceMonthly : p.priceYearly
+          return (
+            <button
+              key={id}
+              type="button"
+              className={`${s.planOption} ${plan === id ? s.planOptionActive : ''}`}
+              onClick={() => setPlan(id)}
+              aria-pressed={plan === id}
+            >
+              <div className={s.planOptionHeader}>
+                <span className={s.planName}>{p.name}</span>
+                <span className={s.planPrice}>
+                  {price} kr
+                  <span className={s.planPriceUnit}>/{interval === 'month' ? 'mo' : 'yr'}</span>
+                </span>
+              </div>
+              <div className={s.planFeatures}>
+                <span>{p.equipment} equipment items</span>
+                <span className={s.featureSep}>·</span>
+                <span>{p.users} members</span>
+              </div>
+            </button>
+          )
+        })}
       </div>
 
       <div className={s.sectionLabel}>

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -32,3 +32,11 @@ env:
     secret: STRIPE_PRICE_STARTER_YEARLY
     availability:
       - RUNTIME
+  - variable: STRIPE_PRICE_BASIC_MONTHLY
+    secret: STRIPE_PRICE_BASIC_MONTHLY
+    availability:
+      - RUNTIME
+  - variable: STRIPE_PRICE_BASIC_YEARLY
+    secret: STRIPE_PRICE_BASIC_YEARLY
+    availability:
+      - RUNTIME

--- a/components/settings/SubscriptionView.module.css
+++ b/components/settings/SubscriptionView.module.css
@@ -69,6 +69,52 @@
   color: var(--mid);
 }
 
+/* Plan cards (active/trialing branch) — informational, highlights current plan */
+.planPickerGrid {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+}
+
+.planPickerCard {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid rgba(71, 71, 71, 0.3);
+  padding: 16px 20px;
+  position: relative;
+}
+
+.planPickerCardActive {
+  border-color: rgba(238, 204, 2, 0.6);
+}
+
+.planPickerCurrent {
+  margin-top: 4px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* Change-plan action row: button + proration hint */
+.actionRow {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.actionHint {
+  font-size: 11px;
+  color: var(--dim);
+  font-weight: 300;
+}
+
 /* Current plan block */
 .currentPlanBlock {
   border: 1px solid rgba(238, 204, 2, 0.3);

--- a/components/settings/SubscriptionView.module.css
+++ b/components/settings/SubscriptionView.module.css
@@ -32,6 +32,43 @@
   color: var(--mid);
 }
 
+.planPicker {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.planPickerBtn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  border: 1px solid rgba(71, 71, 71, 0.3);
+  padding: 16px 20px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s ease;
+}
+
+.planPickerBtnActive {
+  border-color: rgba(238, 204, 2, 0.6);
+}
+
+.planPickerName {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--white);
+}
+
+.planPickerMeta {
+  font-size: 12px;
+  color: var(--mid);
+}
+
 /* Current plan block */
 .currentPlanBlock {
   border: 1px solid rgba(238, 204, 2, 0.3);

--- a/components/settings/SubscriptionView.tsx
+++ b/components/settings/SubscriptionView.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { createPortalSession, createCheckoutSession } from '@/actions/subscription'
+import { PLAN_CATALOG, PLAN_ORDER, type PlanId } from '@/lib/plans'
 import type { Subscription } from '@/types'
 import styles from './SubscriptionView.module.css'
 
@@ -11,6 +12,7 @@ interface SubscriptionViewProps {
 
 const PLAN_LABELS: Record<string, string> = {
   starter: 'Starter',
+  basic:   'Basic',
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -23,6 +25,7 @@ const STATUS_LABELS: Record<string, string> = {
 export default function SubscriptionView({ subscription }: SubscriptionViewProps) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [plan, setPlan] = useState<PlanId>('starter')
 
   async function handleManage() {
     setLoading(true)
@@ -39,7 +42,7 @@ export default function SubscriptionView({ subscription }: SubscriptionViewProps
   async function handleSubscribe(interval: 'month' | 'year') {
     setLoading(true)
     setError(null)
-    const result = await createCheckoutSession(interval)
+    const result = await createCheckoutSession(interval, plan)
     if ('url' in result) {
       window.location.href = result.url
     } else {
@@ -59,6 +62,26 @@ export default function SubscriptionView({ subscription }: SubscriptionViewProps
             {subscription?.status === 'canceled' ? 'Your subscription has been canceled.' : 'No active subscription.'}
           </p>
           {error && <div className={styles.errorBanner}>{error}</div>}
+
+          <div className={styles.planPicker}>
+            {PLAN_ORDER.map((id) => {
+              const p = PLAN_CATALOG[id]
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  className={`${styles.planPickerBtn} ${plan === id ? styles.planPickerBtnActive : ''}`}
+                  onClick={() => setPlan(id)}
+                  aria-pressed={plan === id}
+                >
+                  <span className={styles.planPickerName}>{p.name}</span>
+                  <span className={styles.planPickerMeta}>{p.priceMonthly} kr/mo · {p.priceYearly} kr/yr</span>
+                  <span className={styles.planPickerMeta}>{p.equipment} equipment · {p.users} members</span>
+                </button>
+              )
+            })}
+          </div>
+
           <div style={{ display: 'flex', gap: 12, marginTop: 16 }}>
             <button
               className={styles.btnManage}

--- a/components/settings/SubscriptionView.tsx
+++ b/components/settings/SubscriptionView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { createPortalSession, createCheckoutSession } from '@/actions/subscription'
+import { createPortalSession, createCheckoutSession, createPlanChangeSession } from '@/actions/subscription'
 import { PLAN_CATALOG, PLAN_ORDER, type PlanId } from '@/lib/plans'
 import type { Subscription } from '@/types'
 import styles from './SubscriptionView.module.css'
@@ -31,6 +31,18 @@ export default function SubscriptionView({ subscription }: SubscriptionViewProps
     setLoading(true)
     setError(null)
     const result = await createPortalSession()
+    if ('url' in result) {
+      window.location.href = result.url
+    } else {
+      setError(result.error)
+      setLoading(false)
+    }
+  }
+
+  async function handleChangePlan() {
+    setLoading(true)
+    setError(null)
+    const result = await createPlanChangeSession()
     if ('url' in result) {
       window.location.href = result.url
     } else {
@@ -137,12 +149,47 @@ export default function SubscriptionView({ subscription }: SubscriptionViewProps
             )}
           </div>
 
+          {/* Available plans — highlights the current plan; switching happens in the Stripe portal */}
+          <div className={styles.planPickerGrid}>
+            {PLAN_ORDER.map((id) => {
+              const p = PLAN_CATALOG[id]
+              const isCurrent = subscription.plan === id
+              return (
+                <div
+                  key={id}
+                  className={`${styles.planPickerCard} ${isCurrent ? styles.planPickerCardActive : ''}`}
+                  aria-current={isCurrent ? 'true' : undefined}
+                >
+                  <span className={styles.planPickerName}>{p.name}</span>
+                  <span className={styles.planPickerMeta}>{p.priceMonthly} kr/mo · {p.priceYearly} kr/yr</span>
+                  <span className={styles.planPickerMeta}>{p.equipment} equipment · {p.users} members</span>
+                  {isCurrent && <span className={styles.planPickerCurrent}>Current</span>}
+                </div>
+              )
+            })}
+          </div>
+
           {/* Error banner */}
           {error && (
             <div className={styles.errorBanner}>
               {error}
             </div>
           )}
+
+          {/* Change plan */}
+          <div className={styles.actionRow}>
+            <button
+              className={styles.btnManage}
+              onClick={handleChangePlan}
+              disabled={loading}
+              type="button"
+            >
+              {loading ? 'Redirecting…' : 'Change Plan'}
+            </button>
+            <span className={styles.actionHint}>
+              Plan changes take effect immediately and are prorated on your next invoice.
+            </span>
+          </div>
 
           {/* Manage billing */}
           <button

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -8,7 +8,7 @@ export type UserRole = 'admin' | 'crew' | 'viewer';
 
 export type SubscriptionStatus = 'trialing' | 'active' | 'past_due' | 'incomplete' | 'canceled';
 
-export type Plan = 'free' | 'starter';
+export type Plan = 'free' | 'starter' | 'basic';
 
 export interface PlanLimits {
   equipment: number;
@@ -18,6 +18,7 @@ export interface PlanLimits {
 export const PLAN_LIMITS: Record<Plan, PlanLimits> = {
   free: { equipment: 0, users: 0 },
   starter: { equipment: 25, users: 10 },
+  basic: { equipment: 100, users: 30 },
 };
 
 export interface CompanySubscription {

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,22 @@
+// Client-safe plan catalog for display (price picker, plan badges).
+// Keep limits in sync with PLAN_LIMITS in lib/subscription.ts (server-only).
+// Prices are in SEK and mirror the Stripe prices for each plan.
+
+export type PlanId = 'starter' | 'basic'
+
+export interface PlanInfo {
+  id: PlanId
+  name: string
+  priceMonthly: number // SEK
+  priceYearly: number  // SEK
+  equipment: number
+  users: number
+}
+
+export const PLAN_CATALOG: Record<PlanId, PlanInfo> = {
+  starter: { id: 'starter', name: 'Starter', priceMonthly: 149, priceYearly: 1490, equipment: 25, users: 10 },
+  basic:   { id: 'basic',   name: 'Basic',   priceMonthly: 390, priceYearly: 3900, equipment: 100, users: 30 },
+}
+
+// Display order in the plan picker (cheapest first).
+export const PLAN_ORDER: PlanId[] = ['starter', 'basic']

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -1,9 +1,10 @@
 import 'server-only'
 
-export type Plan = 'starter'
+export type Plan = 'starter' | 'basic'
 
 export const PLAN_LIMITS: Record<Plan, { equipment: number; users: number }> = {
   starter: { equipment: 25, users: 10 },
+  basic:   { equipment: 100, users: 30 },
 }
 
 // Maps Stripe price IDs to internal plan names.
@@ -11,4 +12,6 @@ export const PLAN_LIMITS: Record<Plan, { equipment: number; users: number }> = {
 export const PRICE_ID_TO_PLAN: Record<string, Plan> = {
   [process.env.STRIPE_PRICE_STARTER_MONTHLY!]: 'starter',
   [process.env.STRIPE_PRICE_STARTER_YEARLY!]:  'starter',
+  [process.env.STRIPE_PRICE_BASIC_MONTHLY!]:   'basic',
+  [process.env.STRIPE_PRICE_BASIC_YEARLY!]:    'basic',
 }

--- a/scripts/setupStripePortal.ts
+++ b/scripts/setupStripePortal.ts
@@ -1,0 +1,123 @@
+/**
+ * setupStripePortal.ts
+ *
+ * Idempotent script to create (or update) the Stripe Billing Portal configuration
+ * for Allocate's plan-change flow.
+ *
+ * Run ONCE per Stripe account (once for alpha/beta test mode, once for prod live mode).
+ * After running, store the printed configuration ID as STRIPE_PORTAL_CONFIG_ID in
+ * .env.local (local dev) and in Google Secret Manager (alpha / beta / prod).
+ *
+ * Usage (loads .env.local for the target environment):
+ *   npx tsx --env-file=.env.local scripts/setupStripePortal.ts
+ *
+ * Required env vars (set in .env.local or export before running):
+ *   STRIPE_SECRET_KEY
+ *   STRIPE_PRICE_STARTER_MONTHLY
+ *   STRIPE_PRICE_STARTER_YEARLY
+ *   STRIPE_PRICE_BASIC_MONTHLY
+ *   STRIPE_PRICE_BASIC_YEARLY
+ *
+ * Optional env vars:
+ *   STRIPE_PORTAL_CONFIG_ID  — if set, updates the existing config instead of creating a new one
+ *
+ * NOTE: In Stripe API version 2026-02-25.clover the `subscription_update.products`
+ * allowlist is silently ignored — enabling `subscription_update` makes ALL active
+ * prices switchable. The `products` array below is therefore informational; the
+ * effective changes this script applies are enabling subscription_update and setting
+ * proration_behavior: 'create_prorations'. The TEST default config already has
+ * subscription_update enabled (2026-06-05), so createPlanChangeSession works against
+ * the dashboard default without STRIPE_PORTAL_CONFIG_ID. Running this is still useful
+ * to (re)set proration_behavior idempotently and to configure the LIVE config pre-launch.
+ */
+
+import Stripe from 'stripe'
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`[setupStripePortal] Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+async function main() {
+  const stripeSecretKey         = requireEnv('STRIPE_SECRET_KEY')
+  const priceStarterMonthly     = requireEnv('STRIPE_PRICE_STARTER_MONTHLY')
+  const priceStarterYearly      = requireEnv('STRIPE_PRICE_STARTER_YEARLY')
+  const priceBasicMonthly       = requireEnv('STRIPE_PRICE_BASIC_MONTHLY')
+  const priceBasicYearly        = requireEnv('STRIPE_PRICE_BASIC_YEARLY')
+  const existingConfigId        = process.env.STRIPE_PORTAL_CONFIG_ID
+
+  const stripe = new Stripe(stripeSecretKey, {
+    apiVersion: '2026-02-25.clover',
+    typescript: true,
+  })
+
+  // Retrieve each price to get its parent product ID
+  console.log('[setupStripePortal] Retrieving prices from Stripe…')
+  const [pStarterMonthly, pStarterYearly, pBasicMonthly, pBasicYearly] = await Promise.all([
+    stripe.prices.retrieve(priceStarterMonthly),
+    stripe.prices.retrieve(priceStarterYearly),
+    stripe.prices.retrieve(priceBasicMonthly),
+    stripe.prices.retrieve(priceBasicYearly),
+  ])
+
+  // Group prices by product, then build the products array
+  const byProduct = new Map<string, string[]>()
+  for (const price of [pStarterMonthly, pStarterYearly, pBasicMonthly, pBasicYearly]) {
+    const productId = typeof price.product === 'string' ? price.product : price.product.id
+    const existing  = byProduct.get(productId) ?? []
+    existing.push(price.id)
+    byProduct.set(productId, existing)
+  }
+
+  const products: Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.Product[] =
+    Array.from(byProduct.entries()).map(([product, prices]) => ({ product, prices }))
+
+  const features: Stripe.BillingPortal.ConfigurationCreateParams.Features = {
+    subscription_update: {
+      enabled:                  true,
+      default_allowed_updates:  ['price'],
+      proration_behavior:       'create_prorations',
+      products,
+    },
+    subscription_cancel: {
+      enabled:            true,
+      mode:               'at_period_end',
+      proration_behavior: 'none',
+    },
+    payment_method_update: {
+      enabled: true,
+    },
+    invoice_history: {
+      enabled: true,
+    },
+    customer_update: {
+      enabled:         true,
+      allowed_updates: ['email', 'address', 'tax_id'],
+    },
+  }
+
+  let configuration: Stripe.BillingPortal.Configuration
+
+  if (existingConfigId) {
+    console.log(`[setupStripePortal] Updating existing config: ${existingConfigId}`)
+    configuration = await stripe.billingPortal.configurations.update(existingConfigId, { features })
+  } else {
+    console.log('[setupStripePortal] Creating new portal configuration…')
+    configuration = await stripe.billingPortal.configurations.create({ features })
+  }
+
+  console.log('\n[setupStripePortal] Done.')
+  console.log(`Configuration ID: ${configuration.id}`)
+  console.log('\nNext step: store this ID as STRIPE_PORTAL_CONFIG_ID in:')
+  console.log('  - .env.local (local dev)')
+  console.log('  - Google Secret Manager → STRIPE_PORTAL_CONFIG_ID (alpha / beta / prod)')
+}
+
+main().catch((err) => {
+  console.error('[setupStripePortal] Fatal error:', err)
+  process.exit(1)
+})

--- a/types/company.ts
+++ b/types/company.ts
@@ -6,7 +6,7 @@ export interface CompanyPreferences {
 }
 
 export type SubscriptionStatus = 'trialing' | 'active' | 'past_due' | 'incomplete' | 'canceled'
-export type Plan = 'starter'
+export type Plan = 'starter' | 'basic'
 export type BillingInterval = 'month' | 'year'
 
 export interface Subscription {


### PR DESCRIPTION
Promotion `alpha` → `beta`. Brings the Basic plan + in-app plan upgrade/downgrade to beta.

Beta stays in **Stripe test mode** (isolated sandbox) — all four `STRIPE_PRICE_*` test secrets already exist in allocate-beta, so the deploy resolves cleanly. No live keys involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)