### PR TITLE
Fix booking range selection and remove default date

### DIFF
--- a/app/(app)/bookings/new/page.tsx
+++ b/app/(app)/bookings/new/page.tsx
@@ -12,9 +12,6 @@ export default async function NewBookingPage() {
     redirect('/bookings')
   }
 
-  const today = new Date()
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-
   const [equipment, company] = await Promise.all([
     getEquipment(session.activeCompanyId),
     getCompany(session.activeCompanyId),
@@ -26,8 +23,8 @@ export default async function NewBookingPage() {
     <BookingFormPage
       companyId={session.activeCompanyId}
       equipment={equipment}
-      defaultStartDate={todayStr}
-      defaultEndDate={todayStr}
+      defaultStartDate=""
+      defaultEndDate=""
       timeSlotMinutes={timeSlotMinutes}
     />
   )

--- a/components/bookings/BookingCalendar.tsx
+++ b/components/bookings/BookingCalendar.tsx
@@ -32,6 +32,9 @@ export default function BookingCalendar({ start, end, onChange }: BookingCalenda
     }
     return new Date(today.getFullYear(), today.getMonth(), 1)
   })
+  // Phase flag: distinguishes "just picked a start" (next click extends to a range)
+  // from a completed selection (next click resets to a new start).
+  const [awaitingEnd, setAwaitingEnd] = useState(false)
 
   const y = view.getFullYear()
   const m = view.getMonth()
@@ -46,11 +49,15 @@ export default function BookingCalendar({ start, end, onChange }: BookingCalenda
 
   function pick(d: Date) {
     const k = keyOf(d)
-    if (!start || (start && end)) {
-      onChange(k, null)
+    if (!awaitingEnd || !start) {
+      // First click: start == end (a valid one-day booking), then await the end.
+      onChange(k, k)
+      setAwaitingEnd(true)
     } else {
+      // Second click: set the end, sorting so the earlier date is the start.
       if (fromKey(k) < fromKey(start)) onChange(k, start)
       else onChange(start, k)
+      setAwaitingEnd(false)
     }
   }
 

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -316,7 +316,7 @@ export default function BookingForm({
 
   // ── derived values ───────────────────────────────────────────────────────
   const itemCount = selectedItems.length
-  const canCreate = !!projectName.trim() && !!startDate && itemCount > 0
+  const canCreate = !!projectName.trim() && !!startDate && !!endDate && itemCount > 0
   const hasDates  = !!startDate
 
   const dateHint = startDate
@@ -378,13 +378,13 @@ export default function BookingForm({
                   <div className={styles.datebox}>
                     <label className={styles.datelabel}>START</label>
                     <span className={startDate ? styles.dateVal : styles.dateValDim}>
-                      {fmtDate(startDate) || 'Pick in calendar'}
+                      {fmtDate(startDate) || '--'}
                     </span>
                   </div>
                   <div className={styles.datebox}>
                     <label className={styles.datelabel}>END</label>
                     <span className={endDate ? styles.dateVal : styles.dateValDim}>
-                      {fmtDate(endDate) || (startDate ? 'Same day' : '—')}
+                      {fmtDate(endDate) || '--'}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Problem
Booking date selection could only ever pick a single day, never a range — even though the data model already has `startDate`/`endDate`. `handleDateChange` collapsed `end` to equal `start`, so the calendar's `pick()` always hit the reset branch and a span never formed. New bookings also defaulted to today, letting users confirm without a deliberate choice.

## Changes
- **Calendar** (`BookingCalendar.tsx`): add an `awaitingEnd` phase flag so click 1 sets a one-day selection (start == end), click 2 extends to a range (sorted), click 3 resets.
- **New booking** (`bookings/new/page.tsx`): start with no selection (empty start/end) instead of today.
- **Form** (`BookingForm.tsx`): require both start and end before CREATE BOOKING enables; show `--` in the START/END readouts when nothing is selected.

## Verification
- `tsc --noEmit` passes.
- ⚠️ Interactive browser verification not run (auth-gated route + separate dev-server dir). Reviewer should walk the empty-state / one-click / range / reverse-order / reset / edit-mode cases on a running session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)