### PR TITLE
Rename booking labels START/END → PICKUP/RETURN

### DIFF
--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -376,13 +376,13 @@ export default function BookingForm({
                 {/* Date readouts */}
                 <div className={styles.dateRow}>
                   <div className={styles.datebox}>
-                    <label className={styles.datelabel}>START</label>
+                    <label className={styles.datelabel}>PICKUP</label>
                     <span className={startDate ? styles.dateVal : styles.dateValDim}>
                       {fmtDate(startDate) || '--'}
                     </span>
                   </div>
                   <div className={styles.datebox}>
-                    <label className={styles.datelabel}>END</label>
+                    <label className={styles.datelabel}>RETURN</label>
                     <span className={endDate ? styles.dateVal : styles.dateValDim}>
                       {fmtDate(endDate) || '--'}
                     </span>
@@ -416,7 +416,7 @@ export default function BookingForm({
                 {timeSlotMinutes !== -1 && !fullDay && (
                   <div className={styles.timeRow}>
                     <div className={styles.timebox}>
-                      <label className={styles.datelabel}>START TIME</label>
+                      <label className={styles.datelabel}>PICKUP TIME</label>
                       <select
                         className={styles.timeSelect}
                         value={startTime}
@@ -428,7 +428,7 @@ export default function BookingForm({
                     </div>
                     <div className={styles.timeSep}>→</div>
                     <div className={styles.timebox}>
-                      <label className={styles.datelabel}>END TIME</label>
+                      <label className={styles.datelabel}>RETURN TIME</label>
                       <select
                         className={styles.timeSelect}
                         value={endTime}


### PR DESCRIPTION
## What
Relabels the four labels in the **DATES** section of the booking form:

| Before | After |
|---|---|
| START | PICKUP |
| END | RETURN |
| START TIME | PICKUP TIME |
| END TIME | RETURN TIME |

## Why
The terms "pickup" and "return" match the rental mental model — equipment is physically picked up and returned. Generic "start/end" wording didn't.

## Scope
UI copy only. No changes to:
- Firestore fields / data model
- Field names (`startDate`, `endDate`, `startTime`, `endTime`) or any logic
- Cloud Functions or types

Other booking views (`BookingDetail`, list/calendar views) use `start`/`end` only as internal identifiers or show the period as a combined range — no user-facing "start/end" words, so nothing else needed changing.

## Verification
- `tsc --noEmit` passes.
- Browser verification of the rendered form was blocked by auth (no login credentials in this session); change is static JSX text with no conditional logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)