### PR TITLE
Allow selecting multiple units per equipment in bookings

### DIFF
--- a/__tests__/bookings/createBooking.test.ts
+++ b/__tests__/bookings/createBooking.test.ts
@@ -453,4 +453,39 @@ describe('createBooking', () => {
       expect((result as { error: string }).error).toContain('exceeds total stock')
     })
   })
+
+  // ── Multiple units per equipment ───────────────────────────────────────────
+
+  describe('multi-unit selection', () => {
+    const UNITS_EQUIP = {
+      name: 'Camera Units',
+      active: true,
+      trackingType: 'units',
+      totalQuantity: 2,
+      requiresApproval: false,
+      approverId: null,
+    }
+
+    it('creates a booking with two units of the same unit-tracked equipment', async () => {
+      const { tx, newDocId } = wireTransaction({
+        [`companies/${COMPANY_ID}`]: ACTIVE_COMPANY_DATA,
+        [`companies/${COMPANY_ID}/equipment/equip-1`]: UNITS_EQUIP,
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-a`]: { active: true },
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-b`]: { active: true },
+        [`users/${ADMIN_SESSION.uid}`]: { name: 'Admin User' },
+      })
+
+      const items = JSON.stringify([
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-a' },
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-b' },
+      ])
+      const result = await createBooking(makeFormData({ items }))
+
+      expect(result).toEqual({ bookingId: newDocId })
+
+      const writtenData = vi.mocked(tx.set).mock.calls[0][1] as Record<string, unknown>
+      expect(writtenData.items).toHaveLength(2)
+      expect(writtenData.unitIds).toEqual(['unit-a', 'unit-b'])
+    })
+  })
 })

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -208,8 +208,10 @@ export default function BookingForm({
     return selectedItems.find((i) => i.equipmentId === id && !i.unitId)?.quantity ?? 0
   }
 
-  function getSelectedUnitId(equipmentId: string): string | undefined {
-    return selectedItems.find((i) => i.equipmentId === equipmentId && i.unitId)?.unitId
+  function getSelectedUnitIds(equipmentId: string): string[] {
+    return selectedItems
+      .filter((i) => i.equipmentId === equipmentId && i.unitId)
+      .map((i) => i.unitId as string)
   }
 
   function setQuantity(id: string, qty: number) {
@@ -224,14 +226,14 @@ export default function BookingForm({
 
   function selectUnit(equipmentId: string, unitId: string) {
     setSelectedItems((prev) => {
-      const without = prev.filter((i) => i.equipmentId !== equipmentId || !i.unitId)
-      return [...without, { equipmentId, unitId, quantity: 1 }]
+      if (prev.some((i) => i.equipmentId === equipmentId && i.unitId === unitId)) return prev
+      return [...prev, { equipmentId, unitId, quantity: 1 }]
     })
     setConflictResult(null)
   }
 
-  function deselectUnit(equipmentId: string) {
-    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId)))
+  function deselectUnit(equipmentId: string, unitId: string) {
+    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId === unitId)))
     setConflictResult(null)
   }
 
@@ -472,8 +474,8 @@ export default function BookingForm({
                   const isOpen = !!openCats[cat]
                   const selCount = items.reduce((n, it) => {
                     const qty = getQuantity(it.id)
-                    const unitId = getSelectedUnitId(it.id)
-                    return n + (qty > 0 || !!unitId ? 1 : 0)
+                    const unitCount = getSelectedUnitIds(it.id).length
+                    return n + (qty > 0 ? 1 : 0) + unitCount
                   }, 0)
                   return (
                     <div key={cat} className={`${styles.cat} ${isOpen ? styles.catOpen : ''}`}>
@@ -498,7 +500,7 @@ export default function BookingForm({
 
                             if (eq.trackingType === 'units') {
                               const units = sortedUnits(eq)
-                              const selectedUnitId = getSelectedUnitId(eq.id)
+                              const selectedUnitIds = getSelectedUnitIds(eq.id)
                               const isUnitOpen = unitOpen.has(eq.id)
                               const bookedUnitIds = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
                               const availableUnits = units.filter((u) => !bookedUnitIds.has(u.id))
@@ -507,7 +509,7 @@ export default function BookingForm({
                               return (
                                 <div
                                   key={eq.id}
-                                  className={`${styles.eq} ${selectedUnitId ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
+                                  className={`${styles.eq} ${selectedUnitIds.length > 0 ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
                                 >
                                   <div className={styles.eqMain}>
                                     <div className={styles.eqInfo}>
@@ -521,7 +523,7 @@ export default function BookingForm({
                                       />
                                       <button
                                         type="button"
-                                        className={`${styles.unitToggle} ${selectedUnitId ? styles.unitToggleOn : ''}`}
+                                        className={`${styles.unitToggle} ${selectedUnitIds.length > 0 ? styles.unitToggleOn : ''}`}
                                         onClick={() => {
                                           const next = !isUnitOpen
                                           setUnitOpen((prev) => {
@@ -531,7 +533,7 @@ export default function BookingForm({
                                           })
                                         }}
                                       >
-                                        {selectedUnitId ? `${1} SELECTED` : 'SELECT'}
+                                        {selectedUnitIds.length > 0 ? `${selectedUnitIds.length} SELECTED` : 'SELECT'}
                                         <svg
                                           width="10" height="6" viewBox="0 0 11 7" fill="none"
                                           style={{ transform: isUnitOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
@@ -545,14 +547,14 @@ export default function BookingForm({
                                     <div className={styles.units}>
                                       {units.map((unit) => {
                                         const isBooked = bookedUnitIds.has(unit.id)
-                                        const isOn = selectedUnitId === unit.id
+                                        const isOn = selectedUnitIds.includes(unit.id)
                                         return (
                                           <button
                                             key={unit.id}
                                             type="button"
                                             disabled={isBooked && !isOn}
                                             className={`${styles.unitChip} ${isOn ? styles.unitChipOn : ''} ${isBooked && !isOn ? styles.unitChipBad : ''}`}
-                                            onClick={() => isOn ? deselectUnit(eq.id) : selectUnit(eq.id, unit.id)}
+                                            onClick={() => isOn ? deselectUnit(eq.id, unit.id) : selectUnit(eq.id, unit.id)}
                                           >
                                             <span className={styles.unitName}>{unit.label}</span>
                                             {unit.serialNumber && (


### PR DESCRIPTION
## What

When creating/editing a booking, unit-tracked equipment now lets you select **multiple units**, not just one. Picking a second unit no longer replaces the first.

## Why

The unit picker's `selectUnit()` stripped any existing unit before adding the new one, so a unit-tracked equipment was capped at one unit per booking. The user needs to book as many units as they want.

## How

The fix is **UI-only** — the data model and backend already support this. Bookings store `items: BookingItem[]` (each unit = one item with `quantity: 1`), `unitIds` is denormalized via `flatMap`, and conflict detection loops per item/unit. `validateItems` allows up to 50 items with no dedupe restriction.

Changes in `components/bookings/BookingForm.tsx`:
- `selectUnit` appends instead of replacing (dedupes by `unitId`)
- `deselectUnit(equipmentId, unitId)` removes only the specified unit
- `getSelectedUnitIds` returns all selected units; toggle shows `N SELECTED`; `eqActive`/chip states key off the array
- category badge counts each selected unit

No changes to types, actions, Firestore rules, or `BookingDetail` (already iterates `items`).

## Tests

- Added a `createBooking` test: two units of the same unit-tracked equipment → asserts both land in `items` and the denormalized `unitIds`.
- `npx tsc --noEmit` clean.
- Pre-existing failing test (`quantity > 1 for individually tracked equipment`) is unrelated — it fails on clean `dev` too (stale `'individual'` trackingType fixture).

## Manual verification (dev server, allocate-alpha)

- New booking → unit-tracked equipment → selected units `01` + `02` → toggle showed **"2 SELECTED"**, footer **"2 items"**, both chips `✓`.
- Deselected `01` → only `01` cleared (`02` stayed `✓`), toggle **"1 SELECTED"**.
- No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)