### PR TITLE
Group units by equipment in booking Pick List

### DIFF
--- a/__tests__/bookings/createBooking.test.ts
+++ b/__tests__/bookings/createBooking.test.ts
@@ -453,4 +453,39 @@ describe('createBooking', () => {
       expect((result as { error: string }).error).toContain('exceeds total stock')
     })
   })
+
+  // ── Multiple units per equipment ───────────────────────────────────────────
+
+  describe('multi-unit selection', () => {
+    const UNITS_EQUIP = {
+      name: 'Camera Units',
+      active: true,
+      trackingType: 'units',
+      totalQuantity: 2,
+      requiresApproval: false,
+      approverId: null,
+    }
+
+    it('creates a booking with two units of the same unit-tracked equipment', async () => {
+      const { tx, newDocId } = wireTransaction({
+        [`companies/${COMPANY_ID}`]: ACTIVE_COMPANY_DATA,
+        [`companies/${COMPANY_ID}/equipment/equip-1`]: UNITS_EQUIP,
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-a`]: { active: true },
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-b`]: { active: true },
+        [`users/${ADMIN_SESSION.uid}`]: { name: 'Admin User' },
+      })
+
+      const items = JSON.stringify([
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-a' },
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-b' },
+      ])
+      const result = await createBooking(makeFormData({ items }))
+
+      expect(result).toEqual({ bookingId: newDocId })
+
+      const writtenData = vi.mocked(tx.set).mock.calls[0][1] as Record<string, unknown>
+      expect(writtenData.items).toHaveLength(2)
+      expect(writtenData.unitIds).toEqual(['unit-a', 'unit-b'])
+    })
+  })
 })

--- a/components/bookings/BookingDetail.module.css
+++ b/components/bookings/BookingDetail.module.css
@@ -252,6 +252,48 @@
   /* inherits meta styles */
 }
 
+/* Grouped unit-tracked equipment: name header + indented unit sub-rows */
+.pickGroup {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroup:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroupHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 12px 0 8px;
+}
+
+.pickGroupUnits {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-left: 14px;
+  padding-left: 14px;
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+/* Unit sub-rows sit inside a group; drop the group's own first/last hairlines */
+.pickSubItem {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroupUnits .pickSubItem:first-child {
+  border-top: none;
+}
+
+.pickGroupUnits .pickSubItem:last-child {
+  border-bottom: none;
+  padding-bottom: 12px;
+}
+
 /* -----------------------------------------------------------------------
    Right column: summary + actions
    ----------------------------------------------------------------------- */

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -137,6 +137,21 @@ export default function BookingDetail({
     return equipment.find((e) => e.id === id)
   }
 
+  // Group pick-list items by equipment, preserving first-seen order and each
+  // item's original index (used for the pick-state key).
+  const pickGroups = (() => {
+    const order: string[] = []
+    const map = new Map<string, Array<{ item: (typeof booking.items)[number]; index: number }>>()
+    booking.items.forEach((item, index) => {
+      if (!map.has(item.equipmentId)) {
+        map.set(item.equipmentId, [])
+        order.push(item.equipmentId)
+      }
+      map.get(item.equipmentId)!.push({ item, index })
+    })
+    return order.map((equipmentId) => ({ equipmentId, entries: map.get(equipmentId)! }))
+  })()
+
   // ---------------------------------------------------------------------------
   // Date formatting
   // ---------------------------------------------------------------------------
@@ -209,12 +224,66 @@ export default function BookingDetail({
               )}
             </div>
             <ul className={styles.pickList}>
-              {booking.items.map((item, index) => {
-                const key = `${item.equipmentId}-${index}`
-                const eq = findEquipment(item.equipmentId)
-                const isPicked = pickedItems.has(key)
-                const unit = eq?.units?.find((u) => u.id === item.unitId) ?? null
+              {pickGroups.map((group) => {
+                const eq = findEquipment(group.equipmentId)
+                const eqName = eq
+                  ? eq.active !== false
+                    ? eq.name
+                    : `${eq.name} (deleted)`
+                  : group.equipmentId
 
+                // Unit-tracked equipment: equipment name as a header, each unit as
+                // its own checkable sub-row.
+                if (eq?.trackingType === 'units') {
+                  return (
+                    <li key={group.equipmentId} className={styles.pickGroup}>
+                      <div className={styles.pickGroupHeader}>
+                        <span className={styles.pickItemName}>{eqName}</span>
+                        {eq?.category && (
+                          <span className={styles.pickItemMeta}>{eq.category}</span>
+                        )}
+                      </div>
+                      <ul className={styles.pickGroupUnits}>
+                        {group.entries.map(({ item, index }) => {
+                          const key = `${item.equipmentId}-${index}`
+                          const isPicked = pickedItems.has(key)
+                          const unit = eq?.units?.find((u) => u.id === item.unitId) ?? null
+                          return (
+                            <li
+                              key={key}
+                              className={`${styles.pickItem} ${styles.pickSubItem} ${canPickList ? styles.pickItemInteractive : ''}`}
+                              onClick={() => canPickList && togglePickedItem(key)}
+                            >
+                              <span
+                                className={`${styles.pickCheckbox} ${isPicked ? styles.pickCheckboxChecked : ''}`}
+                                aria-hidden="true"
+                              >
+                                {isPicked && <span className={styles.pickCheckIcon}>&#10003;</span>}
+                              </span>
+                              <span className={styles.pickItemContent}>
+                                <span
+                                  className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
+                                >
+                                  {unit
+                                    ? unit.active !== false
+                                      ? unit.label
+                                      : `${unit.label} (deleted)`
+                                    : (item.unitId ?? '—')}
+                                  {unit?.serialNumber ? ` · ${unit.serialNumber}` : ''}
+                                </span>
+                              </span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </li>
+                  )
+                }
+
+                // Quantity-tracked equipment: a single checkable row.
+                const { item, index } = group.entries[0]
+                const key = `${item.equipmentId}-${index}`
+                const isPicked = pickedItems.has(key)
                 return (
                   <li
                     key={key}
@@ -231,26 +300,12 @@ export default function BookingDetail({
                       <span
                         className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
                       >
-                        {eq
-                          ? eq.active !== false
-                            ? eq.name
-                            : `${eq.name} (deleted)`
-                          : item.equipmentId}
+                        {eqName}
                       </span>
                       <span className={styles.pickItemMeta}>
                         {eq?.category ?? ''}
-                        {eq?.trackingType === 'quantity' && item.quantity > 1
+                        {item.quantity > 1
                           ? <span className={styles.pickItemQty}>&times;{item.quantity}</span>
-                          : null}
-                        {eq?.trackingType === 'units' && unit
-                          ? (
-                            <span className={styles.pickItemUnit}>
-                              {unit.active !== false
-                                ? unit.label
-                                : `${unit.label} (deleted)`}
-                              {unit.serialNumber ? ` · ${unit.serialNumber}` : ''}
-                            </span>
-                          )
                           : null}
                       </span>
                     </span>

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -208,8 +208,10 @@ export default function BookingForm({
     return selectedItems.find((i) => i.equipmentId === id && !i.unitId)?.quantity ?? 0
   }
 
-  function getSelectedUnitId(equipmentId: string): string | undefined {
-    return selectedItems.find((i) => i.equipmentId === equipmentId && i.unitId)?.unitId
+  function getSelectedUnitIds(equipmentId: string): string[] {
+    return selectedItems
+      .filter((i) => i.equipmentId === equipmentId && i.unitId)
+      .map((i) => i.unitId as string)
   }
 
   function setQuantity(id: string, qty: number) {
@@ -224,14 +226,14 @@ export default function BookingForm({
 
   function selectUnit(equipmentId: string, unitId: string) {
     setSelectedItems((prev) => {
-      const without = prev.filter((i) => i.equipmentId !== equipmentId || !i.unitId)
-      return [...without, { equipmentId, unitId, quantity: 1 }]
+      if (prev.some((i) => i.equipmentId === equipmentId && i.unitId === unitId)) return prev
+      return [...prev, { equipmentId, unitId, quantity: 1 }]
     })
     setConflictResult(null)
   }
 
-  function deselectUnit(equipmentId: string) {
-    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId)))
+  function deselectUnit(equipmentId: string, unitId: string) {
+    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId === unitId)))
     setConflictResult(null)
   }
 
@@ -472,8 +474,8 @@ export default function BookingForm({
                   const isOpen = !!openCats[cat]
                   const selCount = items.reduce((n, it) => {
                     const qty = getQuantity(it.id)
-                    const unitId = getSelectedUnitId(it.id)
-                    return n + (qty > 0 || !!unitId ? 1 : 0)
+                    const unitCount = getSelectedUnitIds(it.id).length
+                    return n + (qty > 0 ? 1 : 0) + unitCount
                   }, 0)
                   return (
                     <div key={cat} className={`${styles.cat} ${isOpen ? styles.catOpen : ''}`}>
@@ -498,7 +500,7 @@ export default function BookingForm({
 
                             if (eq.trackingType === 'units') {
                               const units = sortedUnits(eq)
-                              const selectedUnitId = getSelectedUnitId(eq.id)
+                              const selectedUnitIds = getSelectedUnitIds(eq.id)
                               const isUnitOpen = unitOpen.has(eq.id)
                               const bookedUnitIds = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
                               const availableUnits = units.filter((u) => !bookedUnitIds.has(u.id))
@@ -507,7 +509,7 @@ export default function BookingForm({
                               return (
                                 <div
                                   key={eq.id}
-                                  className={`${styles.eq} ${selectedUnitId ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
+                                  className={`${styles.eq} ${selectedUnitIds.length > 0 ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
                                 >
                                   <div className={styles.eqMain}>
                                     <div className={styles.eqInfo}>
@@ -521,7 +523,7 @@ export default function BookingForm({
                                       />
                                       <button
                                         type="button"
-                                        className={`${styles.unitToggle} ${selectedUnitId ? styles.unitToggleOn : ''}`}
+                                        className={`${styles.unitToggle} ${selectedUnitIds.length > 0 ? styles.unitToggleOn : ''}`}
                                         onClick={() => {
                                           const next = !isUnitOpen
                                           setUnitOpen((prev) => {
@@ -531,7 +533,7 @@ export default function BookingForm({
                                           })
                                         }}
                                       >
-                                        {selectedUnitId ? `${1} SELECTED` : 'SELECT'}
+                                        {selectedUnitIds.length > 0 ? `${selectedUnitIds.length} SELECTED` : 'SELECT'}
                                         <svg
                                           width="10" height="6" viewBox="0 0 11 7" fill="none"
                                           style={{ transform: isUnitOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
@@ -545,14 +547,14 @@ export default function BookingForm({
                                     <div className={styles.units}>
                                       {units.map((unit) => {
                                         const isBooked = bookedUnitIds.has(unit.id)
-                                        const isOn = selectedUnitId === unit.id
+                                        const isOn = selectedUnitIds.includes(unit.id)
                                         return (
                                           <button
                                             key={unit.id}
                                             type="button"
                                             disabled={isBooked && !isOn}
                                             className={`${styles.unitChip} ${isOn ? styles.unitChipOn : ''} ${isBooked && !isOn ? styles.unitChipBad : ''}`}
-                                            onClick={() => isOn ? deselectUnit(eq.id) : selectUnit(eq.id, unit.id)}
+                                            onClick={() => isOn ? deselectUnit(eq.id, unit.id) : selectUnit(eq.id, unit.id)}
                                           >
                                             <span className={styles.unitName}>{unit.label}</span>
                                             {unit.serialNumber && (


### PR DESCRIPTION
## What

In the booking detail **Pick List**, multiple units of the same unit-tracked equipment are now grouped: the equipment name is a header and each unit is its own checkable, indented sub-row. Quantity-tracked equipment still renders as a single row with `×N`.

## Why

Follow-up to multi-unit bookings ([#236](https://github.com/swordh/Allocate/pull/236)). Previously the Pick List rendered one flat row per item, so several units of the same equipment showed as repeated equipment-named rows — hard to read when picking individual physical units.

## How

`components/bookings/BookingDetail.tsx`:
- Group `booking.items` by `equipmentId`, preserving first-seen order and each item's **original index** (so pick keys, the `pickedItems` Set, and the `x / N items` progress are unchanged).
- Unit-tracked → equipment-name header + one checkable unit sub-row each (label + serial, keeps `(deleted)` handling).
- Quantity-tracked → single row as before.

`components/bookings/BookingDetail.module.css`: group wrapper, header row, and indented unit sub-rows (left rule) matching existing tokens.

No changes to data model, actions, types, or rules.

## ⚠️ Stacks on #236

This branch is based on `feature/multi-unit-booking` ([#236](https://github.com/swordh/Allocate/pull/236)), which is not yet merged to `dev`. Merge #236 first; this PR's diff will then reduce to just the Pick List changes.

## Verification

- `npx tsc --noEmit` clean.
- Dev server (allocate-alpha): created a booking with 2 units of the same unit-tracked equipment. Pick List showed **"Sennhiser MKH416"** header with **Audio** category and two indented sub-rows **01** / **02**; progress **0 / 2 → 1 / 2** when ticking one; only the ticked unit toggled (line-through). No console errors. Screenshot captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)