### PR TITLE
Promote dev → alpha

### DIFF
--- a/__tests__/bookings/createBooking.test.ts
+++ b/__tests__/bookings/createBooking.test.ts
@@ -453,4 +453,39 @@ describe('createBooking', () => {
       expect((result as { error: string }).error).toContain('exceeds total stock')
     })
   })
+
+  // ── Multiple units per equipment ───────────────────────────────────────────
+
+  describe('multi-unit selection', () => {
+    const UNITS_EQUIP = {
+      name: 'Camera Units',
+      active: true,
+      trackingType: 'units',
+      totalQuantity: 2,
+      requiresApproval: false,
+      approverId: null,
+    }
+
+    it('creates a booking with two units of the same unit-tracked equipment', async () => {
+      const { tx, newDocId } = wireTransaction({
+        [`companies/${COMPANY_ID}`]: ACTIVE_COMPANY_DATA,
+        [`companies/${COMPANY_ID}/equipment/equip-1`]: UNITS_EQUIP,
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-a`]: { active: true },
+        [`companies/${COMPANY_ID}/equipment/equip-1/units/unit-b`]: { active: true },
+        [`users/${ADMIN_SESSION.uid}`]: { name: 'Admin User' },
+      })
+
+      const items = JSON.stringify([
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-a' },
+        { equipmentId: 'equip-1', quantity: 1, unitId: 'unit-b' },
+      ])
+      const result = await createBooking(makeFormData({ items }))
+
+      expect(result).toEqual({ bookingId: newDocId })
+
+      const writtenData = vi.mocked(tx.set).mock.calls[0][1] as Record<string, unknown>
+      expect(writtenData.items).toHaveLength(2)
+      expect(writtenData.unitIds).toEqual(['unit-a', 'unit-b'])
+    })
+  })
 })

--- a/app/(app)/bookings/new/page.tsx
+++ b/app/(app)/bookings/new/page.tsx
@@ -12,9 +12,6 @@ export default async function NewBookingPage() {
     redirect('/bookings')
   }
 
-  const today = new Date()
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-
   const [equipment, company] = await Promise.all([
     getEquipment(session.activeCompanyId),
     getCompany(session.activeCompanyId),
@@ -26,8 +23,8 @@ export default async function NewBookingPage() {
     <BookingFormPage
       companyId={session.activeCompanyId}
       equipment={equipment}
-      defaultStartDate={todayStr}
-      defaultEndDate={todayStr}
+      defaultStartDate=""
+      defaultEndDate=""
       timeSlotMinutes={timeSlotMinutes}
     />
   )

--- a/components/bookings/BookingCalendar.tsx
+++ b/components/bookings/BookingCalendar.tsx
@@ -32,6 +32,9 @@ export default function BookingCalendar({ start, end, onChange }: BookingCalenda
     }
     return new Date(today.getFullYear(), today.getMonth(), 1)
   })
+  // Phase flag: distinguishes "just picked a start" (next click extends to a range)
+  // from a completed selection (next click resets to a new start).
+  const [awaitingEnd, setAwaitingEnd] = useState(false)
 
   const y = view.getFullYear()
   const m = view.getMonth()
@@ -46,11 +49,15 @@ export default function BookingCalendar({ start, end, onChange }: BookingCalenda
 
   function pick(d: Date) {
     const k = keyOf(d)
-    if (!start || (start && end)) {
-      onChange(k, null)
+    if (!awaitingEnd || !start) {
+      // First click: start == end (a valid one-day booking), then await the end.
+      onChange(k, k)
+      setAwaitingEnd(true)
     } else {
+      // Second click: set the end, sorting so the earlier date is the start.
       if (fromKey(k) < fromKey(start)) onChange(k, start)
       else onChange(start, k)
+      setAwaitingEnd(false)
     }
   }
 

--- a/components/bookings/BookingDetail.module.css
+++ b/components/bookings/BookingDetail.module.css
@@ -252,6 +252,48 @@
   /* inherits meta styles */
 }
 
+/* Grouped unit-tracked equipment: name header + indented unit sub-rows */
+.pickGroup {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroup:first-child {
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroupHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 12px 0 8px;
+}
+
+.pickGroupUnits {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-left: 14px;
+  padding-left: 14px;
+  border-left: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+/* Unit sub-rows sit inside a group; drop the group's own first/last hairlines */
+.pickSubItem {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.pickGroupUnits .pickSubItem:first-child {
+  border-top: none;
+}
+
+.pickGroupUnits .pickSubItem:last-child {
+  border-bottom: none;
+  padding-bottom: 12px;
+}
+
 /* -----------------------------------------------------------------------
    Right column: summary + actions
    ----------------------------------------------------------------------- */

--- a/components/bookings/BookingDetail.tsx
+++ b/components/bookings/BookingDetail.tsx
@@ -137,6 +137,21 @@ export default function BookingDetail({
     return equipment.find((e) => e.id === id)
   }
 
+  // Group pick-list items by equipment, preserving first-seen order and each
+  // item's original index (used for the pick-state key).
+  const pickGroups = (() => {
+    const order: string[] = []
+    const map = new Map<string, Array<{ item: (typeof booking.items)[number]; index: number }>>()
+    booking.items.forEach((item, index) => {
+      if (!map.has(item.equipmentId)) {
+        map.set(item.equipmentId, [])
+        order.push(item.equipmentId)
+      }
+      map.get(item.equipmentId)!.push({ item, index })
+    })
+    return order.map((equipmentId) => ({ equipmentId, entries: map.get(equipmentId)! }))
+  })()
+
   // ---------------------------------------------------------------------------
   // Date formatting
   // ---------------------------------------------------------------------------
@@ -209,12 +224,66 @@ export default function BookingDetail({
               )}
             </div>
             <ul className={styles.pickList}>
-              {booking.items.map((item, index) => {
-                const key = `${item.equipmentId}-${index}`
-                const eq = findEquipment(item.equipmentId)
-                const isPicked = pickedItems.has(key)
-                const unit = eq?.units?.find((u) => u.id === item.unitId) ?? null
+              {pickGroups.map((group) => {
+                const eq = findEquipment(group.equipmentId)
+                const eqName = eq
+                  ? eq.active !== false
+                    ? eq.name
+                    : `${eq.name} (deleted)`
+                  : group.equipmentId
 
+                // Unit-tracked equipment: equipment name as a header, each unit as
+                // its own checkable sub-row.
+                if (eq?.trackingType === 'units') {
+                  return (
+                    <li key={group.equipmentId} className={styles.pickGroup}>
+                      <div className={styles.pickGroupHeader}>
+                        <span className={styles.pickItemName}>{eqName}</span>
+                        {eq?.category && (
+                          <span className={styles.pickItemMeta}>{eq.category}</span>
+                        )}
+                      </div>
+                      <ul className={styles.pickGroupUnits}>
+                        {group.entries.map(({ item, index }) => {
+                          const key = `${item.equipmentId}-${index}`
+                          const isPicked = pickedItems.has(key)
+                          const unit = eq?.units?.find((u) => u.id === item.unitId) ?? null
+                          return (
+                            <li
+                              key={key}
+                              className={`${styles.pickItem} ${styles.pickSubItem} ${canPickList ? styles.pickItemInteractive : ''}`}
+                              onClick={() => canPickList && togglePickedItem(key)}
+                            >
+                              <span
+                                className={`${styles.pickCheckbox} ${isPicked ? styles.pickCheckboxChecked : ''}`}
+                                aria-hidden="true"
+                              >
+                                {isPicked && <span className={styles.pickCheckIcon}>&#10003;</span>}
+                              </span>
+                              <span className={styles.pickItemContent}>
+                                <span
+                                  className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
+                                >
+                                  {unit
+                                    ? unit.active !== false
+                                      ? unit.label
+                                      : `${unit.label} (deleted)`
+                                    : (item.unitId ?? '—')}
+                                  {unit?.serialNumber ? ` · ${unit.serialNumber}` : ''}
+                                </span>
+                              </span>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </li>
+                  )
+                }
+
+                // Quantity-tracked equipment: a single checkable row.
+                const { item, index } = group.entries[0]
+                const key = `${item.equipmentId}-${index}`
+                const isPicked = pickedItems.has(key)
                 return (
                   <li
                     key={key}
@@ -231,26 +300,12 @@ export default function BookingDetail({
                       <span
                         className={`${styles.pickItemName} ${isPicked ? styles.pickItemNamePicked : ''}`}
                       >
-                        {eq
-                          ? eq.active !== false
-                            ? eq.name
-                            : `${eq.name} (deleted)`
-                          : item.equipmentId}
+                        {eqName}
                       </span>
                       <span className={styles.pickItemMeta}>
                         {eq?.category ?? ''}
-                        {eq?.trackingType === 'quantity' && item.quantity > 1
+                        {item.quantity > 1
                           ? <span className={styles.pickItemQty}>&times;{item.quantity}</span>
-                          : null}
-                        {eq?.trackingType === 'units' && unit
-                          ? (
-                            <span className={styles.pickItemUnit}>
-                              {unit.active !== false
-                                ? unit.label
-                                : `${unit.label} (deleted)`}
-                              {unit.serialNumber ? ` · ${unit.serialNumber}` : ''}
-                            </span>
-                          )
                           : null}
                       </span>
                     </span>

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -316,7 +316,7 @@ export default function BookingForm({
 
   // ── derived values ───────────────────────────────────────────────────────
   const itemCount = selectedItems.length
-  const canCreate = !!projectName.trim() && !!startDate && itemCount > 0
+  const canCreate = !!projectName.trim() && !!startDate && !!endDate && itemCount > 0
   const hasDates  = !!startDate
 
   const dateHint = startDate
@@ -378,13 +378,13 @@ export default function BookingForm({
                   <div className={styles.datebox}>
                     <label className={styles.datelabel}>START</label>
                     <span className={startDate ? styles.dateVal : styles.dateValDim}>
-                      {fmtDate(startDate) || 'Pick in calendar'}
+                      {fmtDate(startDate) || '--'}
                     </span>
                   </div>
                   <div className={styles.datebox}>
                     <label className={styles.datelabel}>END</label>
                     <span className={endDate ? styles.dateVal : styles.dateValDim}>
-                      {fmtDate(endDate) || (startDate ? 'Same day' : '—')}
+                      {fmtDate(endDate) || '--'}
                     </span>
                   </div>
                 </div>

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -208,8 +208,10 @@ export default function BookingForm({
     return selectedItems.find((i) => i.equipmentId === id && !i.unitId)?.quantity ?? 0
   }
 
-  function getSelectedUnitId(equipmentId: string): string | undefined {
-    return selectedItems.find((i) => i.equipmentId === equipmentId && i.unitId)?.unitId
+  function getSelectedUnitIds(equipmentId: string): string[] {
+    return selectedItems
+      .filter((i) => i.equipmentId === equipmentId && i.unitId)
+      .map((i) => i.unitId as string)
   }
 
   function setQuantity(id: string, qty: number) {
@@ -224,14 +226,14 @@ export default function BookingForm({
 
   function selectUnit(equipmentId: string, unitId: string) {
     setSelectedItems((prev) => {
-      const without = prev.filter((i) => i.equipmentId !== equipmentId || !i.unitId)
-      return [...without, { equipmentId, unitId, quantity: 1 }]
+      if (prev.some((i) => i.equipmentId === equipmentId && i.unitId === unitId)) return prev
+      return [...prev, { equipmentId, unitId, quantity: 1 }]
     })
     setConflictResult(null)
   }
 
-  function deselectUnit(equipmentId: string) {
-    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId)))
+  function deselectUnit(equipmentId: string, unitId: string) {
+    setSelectedItems((prev) => prev.filter((i) => !(i.equipmentId === equipmentId && i.unitId === unitId)))
     setConflictResult(null)
   }
 
@@ -472,8 +474,8 @@ export default function BookingForm({
                   const isOpen = !!openCats[cat]
                   const selCount = items.reduce((n, it) => {
                     const qty = getQuantity(it.id)
-                    const unitId = getSelectedUnitId(it.id)
-                    return n + (qty > 0 || !!unitId ? 1 : 0)
+                    const unitCount = getSelectedUnitIds(it.id).length
+                    return n + (qty > 0 ? 1 : 0) + unitCount
                   }, 0)
                   return (
                     <div key={cat} className={`${styles.cat} ${isOpen ? styles.catOpen : ''}`}>
@@ -498,7 +500,7 @@ export default function BookingForm({
 
                             if (eq.trackingType === 'units') {
                               const units = sortedUnits(eq)
-                              const selectedUnitId = getSelectedUnitId(eq.id)
+                              const selectedUnitIds = getSelectedUnitIds(eq.id)
                               const isUnitOpen = unitOpen.has(eq.id)
                               const bookedUnitIds = new Set(bookedSummary?.[eq.id]?.unitIds ?? [])
                               const availableUnits = units.filter((u) => !bookedUnitIds.has(u.id))
@@ -507,7 +509,7 @@ export default function BookingForm({
                               return (
                                 <div
                                   key={eq.id}
-                                  className={`${styles.eq} ${selectedUnitId ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
+                                  className={`${styles.eq} ${selectedUnitIds.length > 0 ? styles.eqActive : ''} ${hasConflict ? styles.eqConflict : ''}`}
                                 >
                                   <div className={styles.eqMain}>
                                     <div className={styles.eqInfo}>
@@ -521,7 +523,7 @@ export default function BookingForm({
                                       />
                                       <button
                                         type="button"
-                                        className={`${styles.unitToggle} ${selectedUnitId ? styles.unitToggleOn : ''}`}
+                                        className={`${styles.unitToggle} ${selectedUnitIds.length > 0 ? styles.unitToggleOn : ''}`}
                                         onClick={() => {
                                           const next = !isUnitOpen
                                           setUnitOpen((prev) => {
@@ -531,7 +533,7 @@ export default function BookingForm({
                                           })
                                         }}
                                       >
-                                        {selectedUnitId ? `${1} SELECTED` : 'SELECT'}
+                                        {selectedUnitIds.length > 0 ? `${selectedUnitIds.length} SELECTED` : 'SELECT'}
                                         <svg
                                           width="10" height="6" viewBox="0 0 11 7" fill="none"
                                           style={{ transform: isUnitOpen ? 'rotate(180deg)' : 'none', transition: 'transform .15s' }}
@@ -545,14 +547,14 @@ export default function BookingForm({
                                     <div className={styles.units}>
                                       {units.map((unit) => {
                                         const isBooked = bookedUnitIds.has(unit.id)
-                                        const isOn = selectedUnitId === unit.id
+                                        const isOn = selectedUnitIds.includes(unit.id)
                                         return (
                                           <button
                                             key={unit.id}
                                             type="button"
                                             disabled={isBooked && !isOn}
                                             className={`${styles.unitChip} ${isOn ? styles.unitChipOn : ''} ${isBooked && !isOn ? styles.unitChipBad : ''}`}
-                                            onClick={() => isOn ? deselectUnit(eq.id) : selectUnit(eq.id, unit.id)}
+                                            onClick={() => isOn ? deselectUnit(eq.id, unit.id) : selectUnit(eq.id, unit.id)}
                                           >
                                             <span className={styles.unitName}>{unit.label}</span>
                                             {unit.serialNumber && (

--- a/components/bookings/BookingForm.tsx
+++ b/components/bookings/BookingForm.tsx
@@ -376,13 +376,13 @@ export default function BookingForm({
                 {/* Date readouts */}
                 <div className={styles.dateRow}>
                   <div className={styles.datebox}>
-                    <label className={styles.datelabel}>START</label>
+                    <label className={styles.datelabel}>PICKUP</label>
                     <span className={startDate ? styles.dateVal : styles.dateValDim}>
                       {fmtDate(startDate) || '--'}
                     </span>
                   </div>
                   <div className={styles.datebox}>
-                    <label className={styles.datelabel}>END</label>
+                    <label className={styles.datelabel}>RETURN</label>
                     <span className={endDate ? styles.dateVal : styles.dateValDim}>
                       {fmtDate(endDate) || '--'}
                     </span>
@@ -416,7 +416,7 @@ export default function BookingForm({
                 {timeSlotMinutes !== -1 && !fullDay && (
                   <div className={styles.timeRow}>
                     <div className={styles.timebox}>
-                      <label className={styles.datelabel}>START TIME</label>
+                      <label className={styles.datelabel}>PICKUP TIME</label>
                       <select
                         className={styles.timeSelect}
                         value={startTime}
@@ -428,7 +428,7 @@ export default function BookingForm({
                     </div>
                     <div className={styles.timeSep}>→</div>
                     <div className={styles.timebox}>
-                      <label className={styles.datelabel}>END TIME</label>
+                      <label className={styles.datelabel}>RETURN TIME</label>
                       <select
                         className={styles.timeSelect}
                         value={endTime}

--- a/scripts/setupStripeLive.ts
+++ b/scripts/setupStripeLive.ts
@@ -1,0 +1,229 @@
+/**
+ * setupStripeLive.ts
+ *
+ * Idempotent, per-account setup for one Allocate environment's Stripe account.
+ * Creates (or reuses) Products, Prices, the webhook endpoint and the Billing
+ * Portal configuration, then writes the resulting values into that environment's
+ * Google Secret Manager.
+ *
+ * Designed for LIVE-mode setup of beta and prod (each on its OWN Stripe account),
+ * but works for any account/mode. Run it ONCE per Stripe account, in YOUR own
+ * terminal, so the secret key never leaves your machine.
+ *
+ * Usage:
+ *   # 1) Preview (no writes anywhere):
+ *   STRIPE_SECRET_KEY=sk_live_xxx GCP_PROJECT=allocate-beta \
+ *     APP_URL=https://beta.allocate.at \
+ *     npx tsx scripts/setupStripeLive.ts
+ *
+ *   # 2) Apply (creates Stripe resources + writes Secret Manager versions):
+ *   STRIPE_SECRET_KEY=sk_live_xxx GCP_PROJECT=allocate-beta \
+ *     APP_URL=https://beta.allocate.at APPLY=yes \
+ *     npx tsx scripts/setupStripeLive.ts
+ *
+ * Required env:
+ *   STRIPE_SECRET_KEY  live (sk_live_…) or test (sk_test_…) secret key
+ *   GCP_PROJECT        target Firebase/GCP project (e.g. allocate-beta, allocate-e0735)
+ *   APP_URL            canonical https base URL; webhook = APP_URL + /api/webhooks/stripe
+ *
+ * Optional env:
+ *   CURRENCY           ISO currency, default 'sek'
+ *   APPLY              'yes' to perform writes; anything else = dry run
+ *
+ * Prerequisites: the Stripe account must be ACTIVATED for the chosen mode
+ * (live payments require business + bank verification in the Stripe Dashboard),
+ * and you must be authenticated to GCP (`gcloud auth login`) with rights to write
+ * secrets in GCP_PROJECT.
+ *
+ * NOTE: A webhook signing secret (whsec_…) is only returned by Stripe when the
+ * endpoint is CREATED. If an endpoint for APP_URL already exists, this script
+ * cannot read its secret back — it will tell you to either keep the existing
+ * STRIPE_WEBHOOK_SECRET in Secret Manager or roll the secret in the Dashboard.
+ */
+
+import Stripe from 'stripe'
+import { execFileSync } from 'node:child_process'
+
+// ── Plan catalogue (amounts in MINOR units; SEK öre). Mirrors lib/plans.ts. ──
+const CURRENCY = process.env.CURRENCY ?? 'sek'
+const PLANS = {
+  starter: { name: 'Starter', month: 14900, year: 149000 },
+  basic:   { name: 'Basic',   month: 39000, year: 390000 },
+} as const
+type PlanId = keyof typeof PLANS
+type Interval = 'month' | 'year'
+
+const WEBHOOK_EVENTS: Stripe.WebhookEndpointCreateParams.EnabledEvent[] = [
+  'checkout.session.completed',
+  'customer.subscription.created',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'invoice.payment_failed',
+]
+
+// Secret env var name -> price lookup_key, for Secret Manager writes.
+const PRICE_SECRET_BY_KEY: Record<string, { plan: PlanId; interval: Interval }> = {
+  STRIPE_PRICE_STARTER_MONTHLY: { plan: 'starter', interval: 'month' },
+  STRIPE_PRICE_STARTER_YEARLY:  { plan: 'starter', interval: 'year' },
+  STRIPE_PRICE_BASIC_MONTHLY:   { plan: 'basic',   interval: 'month' },
+  STRIPE_PRICE_BASIC_YEARLY:    { plan: 'basic',   interval: 'year' },
+}
+
+function req(name: string): string {
+  const v = process.env[name]
+  if (!v) { console.error(`[setupStripeLive] Missing required env: ${name}`); process.exit(1) }
+  return v
+}
+
+function lookupKey(plan: PlanId, interval: Interval): string {
+  return `allocate_${plan}_${interval}`
+}
+
+async function main() {
+  const secretKey  = req('STRIPE_SECRET_KEY')
+  const gcpProject = req('GCP_PROJECT')
+  const appUrl     = req('APP_URL').replace(/\/+$/, '')
+  const apply      = process.env.APPLY === 'yes'
+
+  if (!appUrl.startsWith('https://')) {
+    console.error('[setupStripeLive] APP_URL must be https://'); process.exit(1)
+  }
+  const mode = secretKey.startsWith('sk_live_') ? 'LIVE' : secretKey.startsWith('sk_test_') ? 'TEST' : 'UNKNOWN'
+  const webhookUrl = `${appUrl}/api/webhooks/stripe`
+
+  console.log('────────────────────────────────────────────────────')
+  console.log(`[setupStripeLive] mode=${mode}  project=${gcpProject}  apply=${apply}`)
+  console.log(`[setupStripeLive] webhook=${webhookUrl}  currency=${CURRENCY}`)
+  console.log('────────────────────────────────────────────────────')
+  if (!apply) console.log('DRY RUN — no Stripe resources created, no secrets written. Set APPLY=yes to execute.\n')
+
+  const stripe = new Stripe(secretKey, { apiVersion: '2026-02-25.clover', typescript: true })
+
+  // ── 1. Products ────────────────────────────────────────────────────────────
+  const productIdByPlan: Record<PlanId, string> = { starter: '', basic: '' }
+  for (const plan of Object.keys(PLANS) as PlanId[]) {
+    const found = await stripe.products.search({ query: `metadata['allocate_plan']:'${plan}'`, limit: 1 })
+    if (found.data[0]) {
+      productIdByPlan[plan] = found.data[0].id
+      console.log(`product ${plan}: reuse ${found.data[0].id}`)
+    } else if (apply) {
+      const p = await stripe.products.create({ name: `Allocate ${PLANS[plan].name}`, metadata: { allocate_plan: plan } })
+      productIdByPlan[plan] = p.id
+      console.log(`product ${plan}: created ${p.id}`)
+    } else {
+      console.log(`product ${plan}: WOULD create`)
+    }
+  }
+
+  // ── 2. Prices (idempotent by lookup_key) ─────────────────────────────────────
+  const priceIdByKey: Record<string, string> = {}
+  for (const [secretName, { plan, interval }] of Object.entries(PRICE_SECRET_BY_KEY)) {
+    const lk = lookupKey(plan, interval)
+    const existing = await stripe.prices.list({ lookup_keys: [lk], active: true, limit: 1 })
+    if (existing.data[0]) {
+      priceIdByKey[secretName] = existing.data[0].id
+      console.log(`price ${lk}: reuse ${existing.data[0].id}`)
+    } else if (apply) {
+      const price = await stripe.prices.create({
+        product: productIdByPlan[plan],
+        currency: CURRENCY,
+        unit_amount: PLANS[plan][interval],
+        recurring: { interval },
+        lookup_key: lk,
+        transfer_lookup_key: true,
+      })
+      priceIdByKey[secretName] = price.id
+      console.log(`price ${lk}: created ${price.id} (${PLANS[plan][interval]} ${CURRENCY}/${interval})`)
+    } else {
+      console.log(`price ${lk}: WOULD create (${PLANS[plan][interval]} ${CURRENCY}/${interval})`)
+    }
+  }
+
+  // ── 3. Webhook endpoint ──────────────────────────────────────────────────────
+  let webhookSecret: string | undefined
+  const endpoints = await stripe.webhookEndpoints.list({ limit: 100 })
+  const existingEp = endpoints.data.find((e) => e.url === webhookUrl)
+  if (existingEp) {
+    console.log(`webhook: reuse ${existingEp.id} (secret not retrievable via API — keep existing STRIPE_WEBHOOK_SECRET or roll it in the Dashboard)`)
+  } else if (apply) {
+    const ep = await stripe.webhookEndpoints.create({ url: webhookUrl, enabled_events: WEBHOOK_EVENTS })
+    webhookSecret = ep.secret
+    console.log(`webhook: created ${ep.id}`)
+  } else {
+    console.log(`webhook: WOULD create -> ${webhookUrl}`)
+  }
+
+  // ── 4. Billing Portal configuration (enable plan switching) ──────────────────
+  const portalFeatures: Stripe.BillingPortal.ConfigurationCreateParams.Features = {
+    subscription_update: {
+      enabled: true,
+      default_allowed_updates: ['price'],
+      proration_behavior: 'create_prorations',
+      // products allowlist is silently ignored in 2026-02-25.clover (all active prices switchable)
+      products: (Object.keys(PLANS) as PlanId[]).map((plan) => ({
+        product: productIdByPlan[plan],
+        prices: (['month', 'year'] as Interval[])
+          .map((iv) => priceIdByKey[Object.keys(PRICE_SECRET_BY_KEY).find(
+            (k) => PRICE_SECRET_BY_KEY[k].plan === plan && PRICE_SECRET_BY_KEY[k].interval === iv)!])
+          .filter(Boolean),
+      })).filter((p) => p.prices.length > 0),
+    },
+    subscription_cancel: { enabled: true, mode: 'at_period_end' },
+    payment_method_update: { enabled: true },
+    invoice_history: { enabled: true },
+    customer_update: { enabled: true, allowed_updates: ['email', 'address', 'tax_id'] },
+  }
+  const configs = await stripe.billingPortal.configurations.list({ limit: 100 })
+  const defaultCfg = configs.data.find((c) => c.is_default)
+  if (apply) {
+    if (defaultCfg) {
+      const c = await stripe.billingPortal.configurations.update(defaultCfg.id, { features: portalFeatures })
+      console.log(`portal: updated default config ${c.id} (subscription_update enabled)`)
+    } else {
+      const c = await stripe.billingPortal.configurations.create({ features: portalFeatures })
+      console.log(`portal: created config ${c.id} (is_default=${c.is_default})`)
+    }
+  } else {
+    console.log(`portal: WOULD ${defaultCfg ? `update default ${defaultCfg.id}` : 'create new config'} with subscription_update enabled`)
+  }
+
+  // ── 5. Write Secret Manager versions ─────────────────────────────────────────
+  const secretsToWrite: Record<string, string> = { STRIPE_SECRET_KEY: secretKey, ...priceIdByKey }
+  if (webhookSecret) secretsToWrite.STRIPE_WEBHOOK_SECRET = webhookSecret
+
+  console.log('\nSecret Manager writes:')
+  for (const [name, value] of Object.entries(secretsToWrite)) {
+    const masked = name.includes('SECRET') || name === 'STRIPE_SECRET_KEY' ? `${value.slice(0, 8)}…` : value
+    if (!apply) { console.log(`  WOULD set ${name} = ${masked}`); continue }
+    ensureSecretExists(gcpProject, name)
+    execFileSync('gcloud', ['secrets', 'versions', 'add', name, `--project=${gcpProject}`, '--data-file=-'],
+      { input: value, stdio: ['pipe', 'ignore', 'inherit'] })
+    console.log(`  set ${name} = ${masked}`)
+  }
+  if (apply && !webhookSecret && !existingEp) {
+    console.log('  WARNING: webhook just created but no secret captured — re-run or set STRIPE_WEBHOOK_SECRET manually.')
+  }
+  if (apply && existingEp) {
+    console.log('  NOTE: STRIPE_WEBHOOK_SECRET left unchanged (endpoint already existed).')
+  }
+
+  console.log('\nDone.')
+  if (apply) {
+    console.log(`Next: redeploy ${gcpProject} so the new secret versions are picked up`)
+    console.log('  (App Hosting resolves secret versions at deploy time — push/redeploy the serving branch).')
+  } else {
+    console.log('Re-run with APPLY=yes to execute.')
+  }
+}
+
+function ensureSecretExists(project: string, name: string) {
+  try {
+    execFileSync('gcloud', ['secrets', 'describe', name, `--project=${project}`], { stdio: 'ignore' })
+  } catch {
+    execFileSync('gcloud', ['secrets', 'create', name, `--project=${project}`, '--replication-policy=automatic'],
+      { stdio: 'inherit' })
+    console.log(`  created secret ${name}`)
+  }
+}
+
+main().catch((err) => { console.error('[setupStripeLive] Fatal:', err); process.exit(1) })


### PR DESCRIPTION
## Summary
- Promote all recent dev changes to alpha for testing

## Commits included
- Group units by equipment in booking Pick List
- Allow selecting multiple units per equipment in bookings
- Rename booking date/time labels START/END → PICKUP/RETURN
- Fix booking range selection and remove default date
- Stripe live setup tool
- Basic plan (390kr/mo, 3900kr/yr) + plan upgrade/downgrade UI
- Invite emails via Resend
- Auth action URL rewrite

## Test plan
- [ ] Verify alpha deploy succeeds
- [ ] Smoke-test booking flow (multi-unit, pickup/return labels, date range)
- [ ] Verify plan picker and Stripe Billing Portal in test mode
- [ ] Verify invitation emails work