### PR TITLE
Route auth emails through Resend with allocate.at links

### DIFF
--- a/actions/auth-email.ts
+++ b/actions/auth-email.ts
@@ -1,0 +1,143 @@
+'use server'
+
+import type { ActionCodeSettings } from 'firebase-admin/auth'
+import { adminAuth, adminDb } from '@/lib/firebase-admin'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Resolves the public app URL used to build our own action links. Must be a
+ * domain listed in Firebase Auth → Authorized domains, otherwise generateLink
+ * rejects the ActionCodeSettings.
+ */
+function appUrl(): string {
+  const url = process.env.NEXT_PUBLIC_APP_URL
+  if (!url) throw new Error('NEXT_PUBLIC_APP_URL not set')
+  return url.replace(/\/$/, '')
+}
+
+/**
+ * The oobCode bridge. Firebase mints an action link pointing at its own
+ * /__/auth/action handler; we keep only the one-time `oobCode` and rebuild the
+ * link against our own /auth/action page so the email never exposes a Firebase
+ * domain. Returns a clean allocate.at URL.
+ */
+function toActionUrl(firebaseLink: string, fallbackMode: string): string {
+  const parsed = new URL(firebaseLink)
+  const oobCode = parsed.searchParams.get('oobCode')
+  const mode = parsed.searchParams.get('mode') ?? fallbackMode
+  if (!oobCode) throw new Error('Firebase link missing oobCode')
+
+  const out = new URL(`${appUrl()}/auth/action`)
+  out.searchParams.set('mode', mode)
+  out.searchParams.set('oobCode', oobCode)
+  return out.toString()
+}
+
+/** Enqueues a mail doc for the onMailQueued Cloud Function to send via Resend. */
+async function queueMail(to: string, template: string, data: Record<string, unknown>): Promise<void> {
+  await adminDb.collection('mail').add({
+    to,
+    template,
+    data,
+    status: 'queued',
+    createdAt: new Date().toISOString(),
+  })
+}
+
+/**
+ * Sends the email-verification link via Resend. The caller's identity is taken
+ * from the verified ID token — never from a client-supplied email — so this
+ * can't be used to spam arbitrary addresses or probe which accounts exist.
+ */
+export async function sendVerificationEmail(idToken: string): Promise<{ error?: string }> {
+  let email: string
+  try {
+    const decoded = await adminAuth.verifyIdToken(idToken)
+    email = decoded.email ?? ''
+  } catch {
+    return { error: 'Invalid session.' }
+  }
+  if (!email) return { error: 'No email on account.' }
+
+  const settings: ActionCodeSettings = { url: `${appUrl()}/auth/action`, handleCodeInApp: false }
+
+  try {
+    const link = await adminAuth.generateEmailVerificationLink(email, settings)
+    await queueMail(email, 'verifyEmail', { verifyUrl: toActionUrl(link, 'verifyEmail') })
+    console.log('[actions/auth-email]', { action: 'verification_sent' })
+    return {}
+  } catch (err) {
+    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
+    console.error('[actions/auth-email]', { code, action: 'verification_failed' })
+    return { error: 'Could not send the verification email. Please try again.' }
+  }
+}
+
+/**
+ * Sends a password-reset link via Resend. Always reports success to the client
+ * (swallows user-not-found) so the form can't be used to enumerate accounts.
+ */
+export async function requestPasswordReset(rawEmail: string): Promise<{ ok: true }> {
+  const email = typeof rawEmail === 'string' ? rawEmail.trim().toLowerCase() : ''
+  if (!EMAIL_RE.test(email)) return { ok: true }
+
+  const settings: ActionCodeSettings = { url: `${appUrl()}/auth/action`, handleCodeInApp: false }
+
+  try {
+    const link = await adminAuth.generatePasswordResetLink(email, settings)
+    await queueMail(email, 'resetPassword', { resetUrl: toActionUrl(link, 'resetPassword') })
+    console.log('[actions/auth-email]', { action: 'reset_sent' })
+  } catch (err) {
+    // user-not-found is expected and intentionally silent. Log anything else.
+    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
+    if (!String(code).includes('user-not-found')) {
+      console.error('[actions/auth-email]', { code, action: 'reset_failed' })
+    }
+  }
+  return { ok: true }
+}
+
+/**
+ * Sends a "confirm your new email" link to the NEW address via Resend. The
+ * change only takes effect once that link is clicked (applyActionCode).
+ */
+export async function requestEmailChange(
+  idToken: string,
+  rawNewEmail: string,
+): Promise<{ error?: string }> {
+  let currentEmail: string
+  try {
+    const decoded = await adminAuth.verifyIdToken(idToken)
+    currentEmail = decoded.email ?? ''
+  } catch {
+    return { error: 'Invalid session.' }
+  }
+  if (!currentEmail) return { error: 'No email on account.' }
+
+  const newEmail = typeof rawNewEmail === 'string' ? rawNewEmail.trim().toLowerCase() : ''
+  if (!EMAIL_RE.test(newEmail)) return { error: 'Enter a valid email address.' }
+  if (newEmail === currentEmail.toLowerCase()) {
+    return { error: 'That’s already your email address.' }
+  }
+
+  const settings: ActionCodeSettings = { url: `${appUrl()}/auth/action`, handleCodeInApp: false }
+
+  try {
+    const link = await adminAuth.generateVerifyAndChangeEmailLink(currentEmail, newEmail, settings)
+    await queueMail(newEmail, 'changeEmail', {
+      verifyUrl: toActionUrl(link, 'verifyAndChangeEmail'),
+      newEmail,
+    })
+    console.log('[actions/auth-email]', { action: 'email_change_sent' })
+    return {}
+  } catch (err) {
+    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
+    // The address is taken by another account — tell the user without leaking more.
+    if (String(code).includes('email-already-exists')) {
+      return { error: 'That email address is already in use.' }
+    }
+    console.error('[actions/auth-email]', { code, action: 'email_change_failed' })
+    return { error: 'Could not send the confirmation email. Please try again.' }
+  }
+}

--- a/actions/auth-email.ts
+++ b/actions/auth-email.ts
@@ -1,7 +1,13 @@
 'use server'
 
+import 'server-only'
 import type { ActionCodeSettings } from 'firebase-admin/auth'
 import { adminAuth, adminDb } from '@/lib/firebase-admin'
+
+/** Canonical error code from a FirebaseAuthError (e.g. 'auth/user-not-found'). */
+function firebaseErrorCode(err: unknown): string {
+  return (err as { code?: string }).code ?? 'unknown'
+}
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -68,8 +74,7 @@ export async function sendVerificationEmail(idToken: string): Promise<{ error?: 
     console.log('[actions/auth-email]', { action: 'verification_sent' })
     return {}
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    console.error('[actions/auth-email]', { code, action: 'verification_failed' })
+    console.error('[actions/auth-email]', { code: firebaseErrorCode(err), action: 'verification_failed' })
     return { error: 'Could not send the verification email. Please try again.' }
   }
 }
@@ -90,8 +95,8 @@ export async function requestPasswordReset(rawEmail: string): Promise<{ ok: true
     console.log('[actions/auth-email]', { action: 'reset_sent' })
   } catch (err) {
     // user-not-found is expected and intentionally silent. Log anything else.
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
-    if (!String(code).includes('user-not-found')) {
+    const code = firebaseErrorCode(err)
+    if (code !== 'auth/user-not-found') {
       console.error('[actions/auth-email]', { code, action: 'reset_failed' })
     }
   }
@@ -132,9 +137,9 @@ export async function requestEmailChange(
     console.log('[actions/auth-email]', { action: 'email_change_sent' })
     return {}
   } catch (err) {
-    const code = err instanceof Error ? (err.message.split('/').pop() ?? 'unknown') : 'unknown'
+    const code = firebaseErrorCode(err)
     // The address is taken by another account — tell the user without leaking more.
-    if (String(code).includes('email-already-exists')) {
+    if (code === 'auth/email-already-exists') {
       return { error: 'That email address is already in use.' }
     }
     console.error('[actions/auth-email]', { code, action: 'email_change_failed' })

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,10 @@
+import ForgotPasswordForm from '@/components/auth/ForgotPasswordForm'
+
+// Server Component shell — ForgotPasswordForm handles the interactive logic.
+export default function ForgotPasswordPage() {
+  return (
+    <main>
+      <ForgotPasswordForm />
+    </main>
+  )
+}

--- a/components/auth/AuthActionHandler.tsx
+++ b/components/auth/AuthActionHandler.tsx
@@ -7,6 +7,7 @@ import {
   applyActionCode,
   verifyPasswordResetCode,
   confirmPasswordReset,
+  signOut,
 } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { createSession } from '@/actions/auth'
@@ -72,9 +73,11 @@ export default function AuthActionHandler({
 
     if (mode === 'verifyAndChangeEmail') {
       applyActionCode(auth, oobCode)
-        .then(() => {
-          // The sign-in email changed, so any existing session is now stale —
-          // send the user back to sign in with the new address.
+        .then(async () => {
+          // The sign-in email changed, so the client identity and any existing
+          // session are now stale — sign out and send the user back to sign in
+          // with the new address.
+          await signOut(auth).catch(() => {})
           setState({ status: 'email_changed' })
           router.push('/login?emailChanged=1')
         })

--- a/components/auth/AuthActionHandler.tsx
+++ b/components/auth/AuthActionHandler.tsx
@@ -19,6 +19,7 @@ type State =
   | { status: 'reset_form'; email: string }
   | { status: 'reset_submitting' }
   | { status: 'reset_done' }
+  | { status: 'email_changed' }
 
 function errorMessage(err: unknown): string {
   const code = (err as { code?: string }).code ?? ''
@@ -64,6 +65,25 @@ export default function AuthActionHandler({
             message: errorMessage(err),
             backTo: '/verify-email',
             backLabel: 'Back to verification',
+          })
+        })
+      return
+    }
+
+    if (mode === 'verifyAndChangeEmail') {
+      applyActionCode(auth, oobCode)
+        .then(() => {
+          // The sign-in email changed, so any existing session is now stale —
+          // send the user back to sign in with the new address.
+          setState({ status: 'email_changed' })
+          router.push('/login?emailChanged=1')
+        })
+        .catch((err) => {
+          setState({
+            status: 'error',
+            message: errorMessage(err),
+            backTo: '/login',
+            backLabel: 'Back to sign in',
           })
         })
       return
@@ -196,6 +216,16 @@ export default function AuthActionHandler({
       <div className={styles.page}>
         <div className={styles.formCard}>
           <h1 className={styles.pageTitle}>Password updated</h1>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.status === 'email_changed') {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>Email updated</h1>
         </div>
       </div>
     )

--- a/components/auth/ForgotPasswordForm.tsx
+++ b/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { requestPasswordReset } from '@/actions/auth-email'
+import styles from './Auth.module.css'
+
+export default function ForgotPasswordForm() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      // Always resolves with { ok: true } — the action never reveals whether
+      // the address has an account (enumeration protection).
+      await requestPasswordReset(email.trim())
+      setSent(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.formCard}>
+          <h1 className={styles.pageTitle}>CHECK YOUR EMAIL</h1>
+          <p>
+            If an account exists for <strong>{email.trim()}</strong>, we’ve sent a
+            link to reset your password.
+          </p>
+          <p className={styles.footer}>
+            <Link href="/login">Back to sign in</Link>
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.formCard}>
+        <h1 className={styles.pageTitle}>RESET PASSWORD</h1>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="email">Email</label>
+            <input
+              id="email"
+              className={styles.input}
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+
+          <button className={styles.submitBtn} type="submit" disabled={loading}>
+            {loading ? 'Sending…' : 'Send reset link'}
+          </button>
+        </form>
+
+        <p className={styles.footer}>
+          <Link href="/login">Back to sign in</Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -3,9 +3,10 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { signInWithEmailAndPassword, sendEmailVerification } from 'firebase/auth'
+import { signInWithEmailAndPassword } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { createSession } from '@/actions/auth'
+import { sendVerificationEmail } from '@/actions/auth-email'
 import styles from './Auth.module.css'
 
 export default function LoginForm() {
@@ -26,7 +27,7 @@ export default function LoginForm() {
       await credential.user.reload()
       const idToken = await credential.user.getIdToken(true)
       if (!credential.user.emailVerified) {
-        sendEmailVerification(credential.user).catch(() => {})
+        sendVerificationEmail(idToken).catch(() => {})
         await createSession(idToken)
         router.push('/verify-email')
       } else {
@@ -93,6 +94,10 @@ export default function LoginForm() {
             {loading ? 'Signing in…' : 'Sign in'}
           </button>
         </form>
+
+        <p className={styles.footer}>
+          <Link href="/forgot-password">Forgot password?</Link>
+        </p>
 
         <p className={styles.footer}>
           No account?{' '}

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -3,11 +3,12 @@
 import { useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
-import { createUserWithEmailAndPassword, sendEmailVerification, updateProfile } from 'firebase/auth'
+import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth'
 import { getFunctions, httpsCallable } from 'firebase/functions'
 import { doc, getDoc } from 'firebase/firestore'
 import { auth, db } from '@/lib/firebase'
 import { setupNewCompany, createSession } from '@/actions/auth'
+import { sendVerificationEmail } from '@/actions/auth-email'
 import { TIMEZONE_OPTIONS } from '@/constants/company'
 import styles from './Auth.module.css'
 
@@ -145,7 +146,7 @@ export default function SignupForm() {
     } catch {/* best-effort — Firestore writes are the source of truth */}
 
     try {
-      await sendEmailVerification(credential.user)
+      await sendVerificationEmail(await credential.user.getIdToken())
     } catch {/* best-effort */}
 
     if (mode === 'invite') {

--- a/components/auth/VerifyEmailForm.tsx
+++ b/components/auth/VerifyEmailForm.tsx
@@ -3,9 +3,10 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { onAuthStateChanged, sendEmailVerification, type User } from 'firebase/auth'
+import { onAuthStateChanged, type User } from 'firebase/auth'
 import { auth } from '@/lib/firebase'
 import { createSession } from '@/actions/auth'
+import { sendVerificationEmail } from '@/actions/auth-email'
 import styles from './Auth.module.css'
 
 export default function VerifyEmailForm() {
@@ -61,15 +62,11 @@ export default function VerifyEmailForm() {
     setSending(true)
     setResendStatus(null)
     try {
-      await sendEmailVerification(currentUser)
-      setResendStatus('Verification email sent')
-    } catch (err) {
-      const code = (err as { code?: string }).code ?? ''
-      if (code === 'auth/too-many-requests') {
-        setResendStatus('Too many attempts. Wait a moment and try again.')
-      } else {
-        setResendStatus('Something went wrong. Please try again.')
-      }
+      const idToken = await currentUser.getIdToken()
+      const result = await sendVerificationEmail(idToken)
+      setResendStatus(result.error ?? 'Verification email sent')
+    } catch {
+      setResendStatus('Something went wrong. Please try again.')
     } finally {
       setSending(false)
     }

--- a/components/settings/AccountSettingsForm.tsx
+++ b/components/settings/AccountSettingsForm.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { updateUserProfile, deleteAccount, exportUserData } from '@/actions/account'
 import { deleteSession } from '@/actions/auth'
+import { requestEmailChange, requestPasswordReset } from '@/actions/auth-email'
+import { auth } from '@/lib/firebase'
 import styles from './AccountSettingsForm.module.css'
 
 interface AccountSettingsFormProps {
@@ -35,6 +37,52 @@ export default function AccountSettingsForm({
 
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
+
+  // Change-email flow: an inline form revealed by "Change Email →".
+  const [showEmailChange, setShowEmailChange] = useState(false)
+  const [newEmail, setNewEmail] = useState('')
+  const [emailSubmitting, setEmailSubmitting] = useState(false)
+  const [emailError, setEmailError] = useState<string | null>(null)
+  const [emailSent, setEmailSent] = useState(false)
+
+  // Change-password flow: sends a reset link to the user's own address.
+  const [passwordSending, setPasswordSending] = useState(false)
+  const [passwordSent, setPasswordSent] = useState(false)
+
+  async function handleEmailChange(e: React.FormEvent) {
+    e.preventDefault()
+    setEmailSubmitting(true)
+    setEmailError(null)
+    try {
+      const user = auth.currentUser
+      if (!user) {
+        setEmailError('Your session expired. Please sign in again.')
+        return
+      }
+      const idToken = await user.getIdToken()
+      const result = await requestEmailChange(idToken, newEmail.trim())
+      if (result.error) {
+        setEmailError(result.error)
+      } else {
+        setEmailSent(true)
+      }
+    } catch {
+      setEmailError('Something went wrong. Please try again.')
+    } finally {
+      setEmailSubmitting(false)
+    }
+  }
+
+  async function handlePasswordReset() {
+    setPasswordSending(true)
+    try {
+      // Reuses the same enumeration-safe action; here we always have the address.
+      await requestPasswordReset(email)
+      setPasswordSent(true)
+    } finally {
+      setPasswordSending(false)
+    }
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -184,18 +232,81 @@ export default function AccountSettingsForm({
             <div className={styles.profileInfoGroup}>
               <span className={styles.profileFieldLabel}>Email</span>
               <p className={styles.profileValue}>{email}</p>
-              <button type="button" className={styles.btnTextLink}>
-                Change Email →
-              </button>
+              {emailSent ? (
+                <p className={styles.profileValue}>
+                  We sent a confirmation link to <strong>{newEmail.trim()}</strong>. The
+                  change takes effect once you click it.
+                </p>
+              ) : !showEmailChange ? (
+                <button
+                  type="button"
+                  className={styles.btnTextLink}
+                  onClick={() => setShowEmailChange(true)}
+                >
+                  Change Email →
+                </button>
+              ) : (
+                <>
+                  <label htmlFor="new-email" className={styles.profileFieldLabel}>
+                    New email
+                  </label>
+                  <input
+                    id="new-email"
+                    type="email"
+                    autoComplete="email"
+                    className={styles.profileNameInput}
+                    value={newEmail}
+                    onChange={(e) => {
+                      setNewEmail(e.target.value)
+                      setEmailError(null)
+                    }}
+                    disabled={emailSubmitting}
+                  />
+                  {emailError && <div className={styles.errorBanner} style={{ marginTop: 12 }}>{emailError}</div>}
+                  <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
+                    <button
+                      type="button"
+                      className={styles.btnTextLink}
+                      onClick={handleEmailChange}
+                      disabled={emailSubmitting || newEmail.trim().length === 0}
+                    >
+                      {emailSubmitting ? 'Sending…' : 'Send confirmation →'}
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.btnTextLink}
+                      onClick={() => {
+                        setShowEmailChange(false)
+                        setNewEmail('')
+                        setEmailError(null)
+                      }}
+                      disabled={emailSubmitting}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              )}
             </div>
 
             {/* Password */}
             <div className={styles.profileInfoGroup}>
               <span className={styles.profileFieldLabel}>Password</span>
               <p className={styles.profileValue}>••••••••••••</p>
-              <button type="button" className={styles.btnTextLink}>
-                Change Password →
-              </button>
+              {passwordSent ? (
+                <p className={styles.profileValue}>
+                  We sent a password-reset link to <strong>{email}</strong>.
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  className={styles.btnTextLink}
+                  onClick={handlePasswordReset}
+                  disabled={passwordSending}
+                >
+                  {passwordSending ? 'Sending…' : 'Change Password →'}
+                </button>
+              )}
             </div>
 
           </div>

--- a/components/settings/AccountSettingsForm.tsx
+++ b/components/settings/AccountSettingsForm.tsx
@@ -49,8 +49,8 @@ export default function AccountSettingsForm({
   const [passwordSending, setPasswordSending] = useState(false)
   const [passwordSent, setPasswordSent] = useState(false)
 
-  async function handleEmailChange(e: React.FormEvent) {
-    e.preventDefault()
+  async function handleEmailChange() {
+    if (emailSubmitting || newEmail.trim().length === 0) return
     setEmailSubmitting(true)
     setEmailError(null)
     try {
@@ -259,6 +259,12 @@ export default function AccountSettingsForm({
                     onChange={(e) => {
                       setNewEmail(e.target.value)
                       setEmailError(null)
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        handleEmailChange()
+                      }
                     }}
                     disabled={emailSubmitting}
                   />

--- a/functions/src/email/onMailQueued.ts
+++ b/functions/src/email/onMailQueued.ts
@@ -4,6 +4,9 @@ import { logger } from 'firebase-functions/v2';
 import { Timestamp } from 'firebase-admin/firestore';
 import { sendEmail, RenderedEmail } from './send';
 import { invitationEmail } from './templates/invitation';
+import { verifyEmailEmail } from './templates/verifyEmail';
+import { resetPasswordEmail } from './templates/resetPassword';
+import { changeEmailEmail } from './templates/changeEmail';
 
 const RESEND_API_KEY = defineSecret('RESEND_API_KEY');
 
@@ -59,6 +62,12 @@ function renderMail(mail: FirebaseFirestore.DocumentData): RenderedEmail {
   switch (mail['template']) {
     case 'invitation':
       return invitationEmail(mail['data']);
+    case 'verifyEmail':
+      return verifyEmailEmail(mail['data']);
+    case 'resetPassword':
+      return resetPasswordEmail(mail['data']);
+    case 'changeEmail':
+      return changeEmailEmail(mail['data']);
     case undefined:
     case null:
     case '': {

--- a/functions/src/email/templates/_shared.ts
+++ b/functions/src/email/templates/_shared.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared building blocks for transactional auth emails (verify, reset, change).
+ * Mirrors the visual language of invitation.ts (ALLOCATE wordmark, white card,
+ * dark CTA button) so every Allocate email looks the same.
+ */
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export interface LayoutOptions {
+  /** Card heading (plain text — escaped internally). */
+  heading: string;
+  /** Intro paragraph HTML. Caller is responsible for escaping any dynamic values. */
+  introHtml: string;
+  buttonLabel: string;
+  buttonUrl: string;
+  /** Small grey footnote shown under the fallback link (plain text — escaped internally). */
+  footnote: string;
+}
+
+/**
+ * Renders the standard Allocate email shell with a single primary action button
+ * and a copy-paste fallback link.
+ */
+export function renderLayout(opts: LayoutOptions): string {
+  const { heading, introHtml, buttonLabel, buttonUrl, footnote } = opts;
+  const safeUrl = escapeHtml(buttonUrl);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 0;">
+    <tr><td align="center">
+      <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e4e4e7;">
+        <tr><td style="padding:28px 32px 8px;">
+          <span style="font-size:15px;font-weight:700;letter-spacing:0.18em;color:#18181b;">ALLOCATE</span>
+        </td></tr>
+        <tr><td style="padding:8px 32px 0;">
+          <h1 style="margin:0;font-size:20px;line-height:1.35;color:#18181b;font-weight:600;">${escapeHtml(heading)}</h1>
+        </td></tr>
+        <tr><td style="padding:14px 32px 0;">
+          <p style="margin:0;font-size:15px;line-height:1.6;color:#3f3f46;">${introHtml}</p>
+        </td></tr>
+        <tr><td style="padding:24px 32px 4px;">
+          <a href="${safeUrl}" style="display:inline-block;background:#18181b;color:#ffffff;text-decoration:none;font-size:15px;font-weight:600;padding:12px 24px;border-radius:8px;">${escapeHtml(buttonLabel)}</a>
+        </td></tr>
+        <tr><td style="padding:20px 32px 28px;">
+          <p style="margin:0;font-size:13px;line-height:1.6;color:#71717a;">
+            If the button doesn’t work, copy and paste this link into your browser:<br>
+            <a href="${safeUrl}" style="color:#71717a;word-break:break-all;">${safeUrl}</a>
+          </p>
+        </td></tr>
+      </table>
+      <p style="margin:18px 0 0;font-size:12px;color:#a1a1aa;">${escapeHtml(footnote)}</p>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}

--- a/functions/src/email/templates/changeEmail.ts
+++ b/functions/src/email/templates/changeEmail.ts
@@ -1,0 +1,37 @@
+import { RenderedEmail } from '../send';
+import { renderLayout, escapeHtml } from './_shared';
+
+export interface ChangeEmailData {
+  verifyUrl: string;
+  /** The new address the user is switching to (shown for confirmation). */
+  newEmail: string;
+}
+
+/**
+ * "Confirm your new email address" email, sent to the NEW address during an
+ * email-change. The verifyUrl is our own allocate.at/auth/action link carrying
+ * the Firebase oobCode (mode=verifyAndChangeEmail).
+ */
+export function changeEmailEmail(data: ChangeEmailData): RenderedEmail {
+  const { verifyUrl, newEmail } = data;
+
+  const subject = 'Confirm your new email address';
+
+  const text = [
+    `You asked to change your Allocate sign-in email to ${newEmail}.`,
+    '',
+    `Confirm the change: ${verifyUrl}`,
+    '',
+    'If you didn’t request this, you can safely ignore this email — nothing will change.',
+  ].join('\n');
+
+  const html = renderLayout({
+    heading: 'Confirm your new email address',
+    introHtml: `You asked to change your Allocate sign-in email to <strong>${escapeHtml(newEmail)}</strong>.`,
+    buttonLabel: 'Confirm change',
+    buttonUrl: verifyUrl,
+    footnote: 'If you didn’t request this, you can safely ignore this email — nothing will change.',
+  });
+
+  return { subject, html, text };
+}

--- a/functions/src/email/templates/resetPassword.ts
+++ b/functions/src/email/templates/resetPassword.ts
@@ -1,0 +1,34 @@
+import { RenderedEmail } from '../send';
+import { renderLayout } from './_shared';
+
+export interface ResetPasswordData {
+  resetUrl: string;
+}
+
+/**
+ * "Reset your password" email. The resetUrl is our own allocate.at/auth/action
+ * link carrying the Firebase oobCode (mode=resetPassword).
+ */
+export function resetPasswordEmail(data: ResetPasswordData): RenderedEmail {
+  const { resetUrl } = data;
+
+  const subject = 'Reset your Allocate password';
+
+  const text = [
+    'We received a request to reset the password for your Allocate account.',
+    '',
+    `Reset your password: ${resetUrl}`,
+    '',
+    'If you didn’t request this, you can safely ignore this email — your password won’t change.',
+  ].join('\n');
+
+  const html = renderLayout({
+    heading: 'Reset your password',
+    introHtml: 'We received a request to reset the password for your Allocate account.',
+    buttonLabel: 'Reset password',
+    buttonUrl: resetUrl,
+    footnote: 'If you didn’t request this, you can safely ignore this email — your password won’t change.',
+  });
+
+  return { subject, html, text };
+}

--- a/functions/src/email/templates/verifyEmail.ts
+++ b/functions/src/email/templates/verifyEmail.ts
@@ -1,0 +1,35 @@
+import { RenderedEmail } from '../send';
+import { renderLayout } from './_shared';
+
+export interface VerifyEmailData {
+  verifyUrl: string;
+}
+
+/**
+ * "Confirm your email address" email. The verifyUrl is our own
+ * allocate.at/auth/action link carrying the Firebase oobCode — never Firebase's
+ * own /__/auth/action link.
+ */
+export function verifyEmailEmail(data: VerifyEmailData): RenderedEmail {
+  const { verifyUrl } = data;
+
+  const subject = 'Confirm your email address';
+
+  const text = [
+    'Confirm your email address to finish setting up your Allocate account.',
+    '',
+    `Confirm your email: ${verifyUrl}`,
+    '',
+    'If you didn’t create an Allocate account, you can safely ignore this email.',
+  ].join('\n');
+
+  const html = renderLayout({
+    heading: 'Confirm your email address',
+    introHtml: 'Confirm your email address to finish setting up your Allocate account.',
+    buttonLabel: 'Confirm email',
+    buttonUrl: verifyUrl,
+    footnote: 'If you didn’t create an Allocate account, you can safely ignore this email.',
+  });
+
+  return { subject, html, text };
+}


### PR DESCRIPTION
## Vad

Ersätter Firebase Auths inbyggda transaktionsmail (mailverifiering, lösenordsåterställning, mailbyte) med egna **Resend**-levererade mail som bär rena **allocate.at**-länkar istället för Firebases `/__/auth/action`-handler.

## Hur — oobCode-bryggan

Firebase erbjuder ingen inställning för att byta SMTP/Resend för sina mail, och "Customize action URL" vägrar App Hosting-domäner. Lösningen kringgår båda:

1. Server actions (`actions/auth-email.ts`) genererar action-länken med Admin SDK
2. Vi plockar ut engångskoden (`oobCode`) och bygger vår egen `${APP_URL}/auth/action`-länk
3. Länken köas som ett `mail/{id}`-dok → befintliga `onMailQueued` skickar via Resend
4. Den befintliga `/auth/action`-sidan löser in koden med klient-SDK:n

Firebase-handlern (`/__/auth/action`) förekommer aldrig i mailen.

## Ändringar

- **Cloud Functions:** nya mallar `verifyEmail`, `resetPassword`, `changeEmail` + delad layout-helper; inkopplade i `onMailQueued`-switchen
- **Server actions:** `sendVerificationEmail` (identitet från verifierad token), `requestPasswordReset` (enumeration-säker), `requestEmailChange`
- **Klientformulär:** Signup/Login/VerifyEmail anropar `sendVerificationEmail` istället för Firebases `sendEmailVerification`
- **AuthActionHandler:** nytt `verifyAndChangeEmail`-läge
- **Ny `/forgot-password`-sida** + form
- **Kontoinställningar:** de tidigare döda "Change Email"/"Change Password"-knapparna kopplade till de nya actions

## Firebase-inställningar (alpha)

Verifierat — **inget behöver ändras**: `NEXT_PUBLIC_APP_URL=https://alpha.allocate.at` är satt, `alpha.allocate.at` finns i Authorized domains, `RESEND_API_KEY` är satt.

## Verifiering (efter promotion till alpha)

- Deploy functions: `firebase use alpha && firebase deploy --only functions`
- Testa signup → verifieringsmail från `noreply@allocate.at` med `alpha.allocate.at/auth/action`-länk
- `/forgot-password` → reset-mail → sätt nytt lösenord
- Settings → Change Email → bekräftelsemail till nya adressen → ändring träder i kraft
- Kontrollera `mail/{id}` går `queued → sent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)