### PR TITLE
Fix: make /forgot-password and /auth/action public in auth proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const PUBLIC_PATHS = ['/login', '/signup', '/invite', '/api/auth/session']
+// /forgot-password and /auth/action must be reachable while signed out:
+// password-reset and email-verification/-change links are clicked from email,
+// often in a fresh session. The oobCode in the link is itself the security
+// token (validated by Firebase), so these pages carry no privileged data.
+const PUBLIC_PATHS = ['/login', '/signup', '/forgot-password', '/auth/action', '/invite', '/api/auth/session']
 
 /**
  * Auth guard for all application routes.


### PR DESCRIPTION
Follow-up to [#240](https://github.com/swordh/Allocate/pull/240). The auth proxy (`proxy.ts`) bounced any signed-out request to `/login`, but the new password-reset entry page (`/forgot-password`) and the oobCode handler (`/auth/action`) are reached **while signed out** — links are clicked from email in a fresh session. Adds both to `PUBLIC_PATHS`.

Found during alpha verification: `/forgot-password` and `/auth/action` returned 307 → `/login`. `/auth/action` was previously parked/unused (Firebase links went to firebaseapp.com), so the gap only surfaced once the oobCode bridge pointed links at our own domain.

Security: the oobCode in the link is the security token (validated by Firebase); these pages carry no privileged data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)