### PR TITLE
Promote to alpha: public auth paths fix (#242)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-const PUBLIC_PATHS = ['/login', '/signup', '/invite', '/api/auth/session']
+// /forgot-password and /auth/action must be reachable while signed out:
+// password-reset and email-verification/-change links are clicked from email,
+// often in a fresh session. The oobCode in the link is itself the security
+// token (validated by Firebase), so these pages carry no privileged data.
+const PUBLIC_PATHS = ['/login', '/signup', '/forgot-password', '/auth/action', '/invite', '/api/auth/session']
 
 /**
  * Auth guard for all application routes.


### PR DESCRIPTION
Promotes the proxy public-paths fix ([#242](https://github.com/swordh/Allocate/pull/242)) so /forgot-password and /auth/action are reachable while signed out on alpha. Requires a manual rollout after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)