### PR TITLE
chore: upgrade Stripe SDK to v22 (apiVersion 2026-06-24.dahlia)

### DIFF
--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -26,7 +26,7 @@ export const stripe: Stripe = lazy(() => {
     throw new Error('[stripe] STRIPE_SECRET_KEY is not set')
   }
   return new Stripe(stripeSecretKey, {
-    apiVersion: '2026-02-25.clover',
+    apiVersion: '2026-06-24.dahlia',
     typescript: true,
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-dom": "19.2.4",
         "react-virtuoso": "^4.18.7",
         "server-only": "^0.0.1",
-        "stripe": "^20.4.1"
+        "stripe": "^22.3.2"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1377,9 +1377,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1395,9 +1392,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1415,9 +1409,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1433,9 +1424,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1453,9 +1441,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1471,9 +1456,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1491,9 +1473,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1510,9 +1489,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1528,9 +1504,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1554,9 +1527,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1578,9 +1548,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1604,9 +1571,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1628,9 +1592,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1654,9 +1615,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1679,9 +1637,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1703,9 +1658,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1927,9 +1879,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1945,9 +1894,6 @@
       "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1965,9 +1911,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1983,9 +1926,6 @@
       "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2253,9 +2193,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2273,9 +2210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2293,9 +2227,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2313,9 +2244,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2333,9 +2261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,9 +2278,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3020,9 +2942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3037,9 +2956,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3054,9 +2970,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3071,9 +2984,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3088,9 +2998,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3105,9 +3012,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3122,9 +3026,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,9 +3040,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6833,9 +6731,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6857,9 +6752,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6881,9 +6773,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6905,9 +6794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8692,15 +8578,15 @@
       }
     },
     "node_modules/stripe": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
-      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
+      "version": "22.3.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.2.tgz",
+      "integrity": "sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@types/node": ">=16"
+        "@types/node": ">=18"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-dom": "19.2.4",
     "react-virtuoso": "^4.18.7",
     "server-only": "^0.0.1",
-    "stripe": "^20.4.1"
+    "stripe": "^22.3.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/scripts/setupStripeLive.ts
+++ b/scripts/setupStripeLive.ts
@@ -97,7 +97,7 @@ async function main() {
   console.log('────────────────────────────────────────────────────')
   if (!apply) console.log('DRY RUN — no Stripe resources created, no secrets written. Set APPLY=yes to execute.\n')
 
-  const stripe = new Stripe(secretKey, { apiVersion: '2026-02-25.clover', typescript: true })
+  const stripe = new Stripe(secretKey, { apiVersion: '2026-06-24.dahlia', typescript: true })
 
   // ── 1. Products ────────────────────────────────────────────────────────────
   const productIdByPlan: Record<PlanId, string> = { starter: '', basic: '' }

--- a/scripts/setupStripePortal.ts
+++ b/scripts/setupStripePortal.ts
@@ -51,7 +51,7 @@ async function main() {
   const existingConfigId        = process.env.STRIPE_PORTAL_CONFIG_ID
 
   const stripe = new Stripe(stripeSecretKey, {
-    apiVersion: '2026-02-25.clover',
+    apiVersion: '2026-06-24.dahlia',
     typescript: true,
   })
 


### PR DESCRIPTION
## Sammanfattning

Uppgraderar Stripe Node-SDK från `^20.4.1` till `^22.3.2` (två major-versioner) och uppdaterar den pinnade `apiVersion`-literalen till den som SDK 22 levererar.

## Ändringar

- `package.json` / `package-lock.json`: `stripe` `^20.4.1` → `^22.3.2` (låst till `22.3.2`)
- `apiVersion`-literal `2026-02-25.clover` → `2026-06-24.dahlia` på tre ställen:
  - `lib/stripe.ts` (runtime-klienten, produktionskritisk)
  - `scripts/setupStripePortal.ts` (engångs setup-script)
  - `scripts/setupStripeLive.ts` (engångs setup-script)

Inga logik- eller datamodelländringar behövdes — integrationen läser redan `subscription.items.data[0].current_period_end` (den moderna platsen efter att fältet flyttades av på prenumerationens items).

## Verifiering

- `tsc --noEmit` grön — bekräftar att `apiVersion`-bytet var enda nödvändiga ändringen; SDK 22 typar `apiVersion` som en literal som bara accepterar `2026-06-24.dahlia`.
- Stripe kompilerar rent i `next build` ("✓ Compiled successfully").
- `__tests__/subscription-gating.test.ts` — 11/11 gröna.

Kvarvarande lint-/testfel i repot (`tools/*.js` require-imports, `createBooking.test.ts`, Firebase `auth/invalid-api-key` vid prerender pga saknade env-variabler i CI-sandlådan) är förbefintliga och orörda av denna ändring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXEVywaoDpmzvFXNuzhDdC)_