### PR TITLE
fix(firestore): add missing invitations email+status collection-group index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -80,6 +80,14 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "expiresAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "invitations",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
Closes #258

## Problem

`functions/src/auth/onUserCreate.ts:33-37` runs on every new signup and is what attaches an invited user to the company that invited them:

```ts
db.collectionGroup('invitations')
  .where('email', '==', email)
  .where('status', '==', 'pending')
```

The `COLLECTION_GROUP email ASC, status ASC` index that serves this query existed **only in prod**. It was created reactively via the console create-link in a Firestore error and never written back to `firestore.indexes.json`, so it never reached alpha or beta.

## Confirmed, not assumed

The issue flagged that Firestore can sometimes serve equality-only queries without a composite index. It cannot here. A read-only probe running the exact query against each project:

| Project | Result |
|---|---|
| allocate-alpha | ❌ `FAILED_PRECONDITION: The query requires an index` |
| allocate-beta | ❌ `FAILED_PRECONDITION: The query requires an index` |
| allocate-e0735 | ✅ served |

So in alpha and beta, an invited user was created in Auth but never joined to their company — a working account with no workspace, and an invitation left `pending`.

## Change

One index added to `firestore.indexes.json`. Already deployed and verified `READY` in alpha and beta; the same probe now passes in all three environments. Prod already had the index and reaches file parity via the normal promotion flow.

## The dead index

`status ASC, invitedAt DESC` (COLLECTION_GROUP, prod only) is deliberately **not** added — `git grep invitedAt` across both `dev` and `origin/main` finds only writes and tests, no query orders by it. It is being deleted from prod separately rather than left to a CLI prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)